### PR TITLE
Improve navigation and navigation-related accessibility

### DIFF
--- a/src/404.njk
+++ b/src/404.njk
@@ -1,7 +1,7 @@
 ---
 permalink: 404.html
 title: "404: Not Found"
-layout: layouts/base.njk
+layout: layouts/page.njk
 ---
 
 <div class="prose max-w-none text-center md:col-span-12">

--- a/src/_includes/layouts/base.njk
+++ b/src/_includes/layouts/base.njk
@@ -69,6 +69,7 @@ description: base layout for site
     {% endif %}
   </head>
   <body class="mx-4 font-body">
+    <a href="#skip" class="sr-only">Skip to main content</a>
     <div class="mx-auto my-2 max-w-5xl space-y-8 md:my-8">
       <header
         role="banner"
@@ -133,6 +134,7 @@ description: base layout for site
       </header>
 
       <main
+        id="skip"
         class="grid gap-y-6 md:grid-cols-12 md:gap-x-4 md:gap-y-8 lg:gap-y-16"
       >
         {{ content | safe }}

--- a/src/_includes/layouts/base.njk
+++ b/src/_includes/layouts/base.njk
@@ -133,12 +133,11 @@ description: base layout for site
         </div>
       </header>
 
-      <main
-        id="skip"
+      <div
         class="grid gap-y-6 md:grid-cols-12 md:gap-x-4 md:gap-y-8 lg:gap-y-16"
       >
         {{ content | safe }}
-      </main>
+      </div>
 
       <footer
         class="flex justify-center border-t-2 py-4 text-center text-xl md:grid-cols-12"

--- a/src/_includes/layouts/blog-post.njk
+++ b/src/_includes/layouts/blog-post.njk
@@ -4,8 +4,8 @@ description: layout for an individual blog post; excerpt at left
 navigationKey: posts
 ---
 
-<div class="md:col-span-4">
-  <div class="space-y-2">
+<div class="relative md:col-span-4">
+  <div class="static space-y-2 md:sticky md:top-0">
     <div class="border-b py-2 font-display">
       <h2 class="text-xl">{{ title }}</h2>
       <h4 class="italic">{{ page.date | localeDate }}</h4>

--- a/src/_includes/layouts/blog-post.njk
+++ b/src/_includes/layouts/blog-post.njk
@@ -30,6 +30,6 @@ navigationKey: posts
 {# Set min-width and overflow to prevent code block blowouts.
  #  See https://stackoverflow.com/questions/55738093/prismjs-not-overflowing-with-css-grid
  #}
-<div class="prose min-w-0 overflow-auto md:col-span-8 md:pl-4">
+<main class="prose min-w-0 overflow-auto md:col-span-8 md:pl-4" id="skip">
   {{ content }}
-</div>
+</main>

--- a/src/_includes/layouts/blog.njk
+++ b/src/_includes/layouts/blog.njk
@@ -5,44 +5,48 @@ description: >
 navigationKey: posts
 ---
 
-<div class="space-y-2 md:col-span-4">
-  <h3 class="border-b pb-2 font-display text-xl">Posts by Tag</h3>
-  <nav>
-    <ul>
-      <li class="font-title">
-        <a
-          href="/blog"
-          class="
-            {% if not activeTag %}
-            text-pank italic border-l-3 border-pank font-semibold
-          {% endif %} pl-2 hover:text-pank
-          "
-          {% if not activeTag %}
-            aria-current="page"
-          {% endif %}
-          >All Posts ({{ collections.post.length }})</a
-        >
-      </li>
-      {% set postTags = collections.post | getAllTagsWithCount %}
-      {% for tag in postTags %}
+<div class="md:col-span-4">
+  <div>
+    <h3 class="border-b pb-2 font-display text-xl">Posts by Tag</h3>
+    <nav
+      class="max-h-40 overflow-auto border-b pt-2 shadow-inner md:max-h-none md:border-none md:shadow-none"
+    >
+      <ul>
         <li class="font-title">
           <a
-            href="/tags/{{ tag.tag | slugify }}"
+            href="/blog"
             class="
-              {% if tag.tag == activeTag %}
+            {% if not activeTag %}
               text-pank italic border-l-3 border-pank font-semibold
             {% endif %} pl-2 hover:text-pank
-            "
-            {% if tag.tag == activeTag %}
+          "
+            {% if not activeTag %}
               aria-current="page"
             {% endif %}
-          >
-            {{- tag.tag -}} &nbsp;({{ tag.count }})</a
+            >All Posts ({{ collections.post.length }})</a
           >
         </li>
-      {% endfor %}
-    </ul>
-  </nav>
+        {% set postTags = collections.post | getAllTagsWithCount %}
+        {% for tag in postTags %}
+          <li class="font-title">
+            <a
+              href="/tags/{{ tag.tag | slugify }}"
+              class="
+              {% if tag.tag == activeTag %}
+                text-pank italic border-l-3 border-pank font-semibold
+              {% endif %} pl-2 hover:text-pank
+            "
+              {% if tag.tag == activeTag %}
+                aria-current="page"
+              {% endif %}
+            >
+              {{- tag.tag -}} &nbsp;({{ tag.count }})</a
+            >
+          </li>
+        {% endfor %}
+      </ul>
+    </nav>
+  </div>
 </div>
 <main class="space-y-8 md:col-span-8" id="skip">
   <h1

--- a/src/_includes/layouts/blog.njk
+++ b/src/_includes/layouts/blog.njk
@@ -44,11 +44,11 @@ navigationKey: posts
     </ul>
   </nav>
 </div>
-<div class="space-y-8 md:col-span-8">
+<main class="space-y-8 md:col-span-8" id="skip">
   <h1
     class="border-l border-l-8 border-pank bg-grey-100 p-2 font-display text-2xl"
   >
     {{ title }}
   </h1>
   {{ content }}
-</div>
+</main>

--- a/src/_includes/layouts/home.njk
+++ b/src/_includes/layouts/home.njk
@@ -35,9 +35,12 @@ navigationKey: about
 {% endmacro %}
 
 {{ subhead("about", "About Lyza") }}
-<div class="prose text-lg md:col-span-6 lg:col-span-7 lg:text-justify">
+<main
+  class="prose text-lg md:col-span-6 lg:col-span-7 lg:text-justify"
+  id="skip"
+>
   {{ content | safe }}
-</div>
+</main>
 
 <div class="flex flex-col gap-y-4 px-2 md:col-span-3 md:gap-y-0">
   <h2 class="border-b pb-2 font-display text-xl md:text-lg lg:text-left">

--- a/src/_includes/layouts/page.njk
+++ b/src/_includes/layouts/page.njk
@@ -1,0 +1,7 @@
+---
+layout: layouts/base.njk
+description: >
+  A layout with a full-width main-content area
+---
+
+<main class="md:col-span-12" id="skip">{{ content | safe }}</main>

--- a/src/blog.njk
+++ b/src/blog.njk
@@ -1,10 +1,34 @@
 ---
 layout: layouts/blog.njk
 title: Bloggy-posties
+pagination:
+  data: collections.post
+  size: 12
+  reverse: true
 ---
 
 <ul class="space-y-8">
-  {% for post in collections.post | reverse %}
+  {% for post in pagination.items %}
     {% include 'components/post-excerpt-list-item.njk' %}
   {% endfor %}
 </ul>
+
+<div
+  class="grid grid-cols-2 text-xl transition-colors"
+  style="font-variant-caps:all-small-caps"
+>
+  <div>
+    {% if pagination.href.previous %}
+      <a class="hover:text-pank" href="{{ pagination.href.previous }}"
+        >« Newer posts</a
+      >
+    {% endif %}
+  </div>
+  <div class="text-right">
+    {% if pagination.href.next %}
+      <a class="hover:text-pank" href="{{ pagination.href.next }}"
+        >Older posts »</a
+      >
+    {% endif %}
+  </div>
+</div>


### PR DESCRIPTION
This PR improves a few a11y and navigation items pertaining mostly to the blog area, including:

* Ensuring there is a skip-to-content link on every page and that the "content" (`main` element) is the appropriate element
* Paginating the blog landing page
* Decreasing the height of the tags-list on the blog landing page on narrower screens. This is an OK solution for now, but could probably be more elegant.
* Make the left column sticky on wider screens on individual blog posts. There's nothing else in that column, so keeping the post title and metadata visible on scroll seems quasi-useful.