### PR TITLE
Add basic print styles

### DIFF
--- a/src/_includes/components/navigation.njk
+++ b/src/_includes/components/navigation.njk
@@ -1,4 +1,4 @@
-<nav>
+<nav class="print:hidden">
   <ul class="flex flex-row gap-4 justify-self-stretch sm:gap-6">
     <li
       class="{% if navigationKey == 'about' %}border-pank{% else %}border-transparent{% endif %} border-b-10 pt-2.5"

--- a/src/_includes/layouts/base.njk
+++ b/src/_includes/layouts/base.njk
@@ -116,7 +116,7 @@ description: base layout for site
             <div class="col-span-1">
               <img
                 src="/images/lyza.gif"
-                class="absolute bottom-0 right-full h-[110px] w-[100px] sm:right-auto sm:h-[170px] sm:w-[155px] sm:scale-x-[-1] lg:h-auto lg:w-auto"
+                class="absolute bottom-0 right-full h-[110px] w-[100px] sm:right-auto sm:h-[170px] sm:w-[155px] sm:scale-x-[-1] lg:h-auto lg:w-auto print:h-[155px] print:w-[140px]"
                 alt="Lyza"
               />
             </div>
@@ -142,7 +142,7 @@ description: base layout for site
       </div>
 
       <footer
-        class="flex justify-center border-t-2 py-4 text-center text-xl"
+        class="flex justify-center border-t-2 py-4 text-center text-xl print:hidden"
         style="font-variant-caps:all-small-caps"
       >
         <div class="flex gap-x-2 px-2">


### PR DESCRIPTION
Don't print top navigation or footer, and size header image to ensure it doesn't get cut off.

Otherwise, print should pick up layout from the small breakpoint in general.