### PR TITLE
Expand PANK color palette

### DIFF
--- a/styles/tailwind.config.js
+++ b/styles/tailwind.config.js
@@ -2,7 +2,20 @@ const colors = require("tailwindcss/colors");
 const defaultTheme = require("tailwindcss/defaultTheme");
 
 const customColors = {
-  pank: "#e60a62",
+  pank: {
+    50: "#fff0f7",
+    100: "#ffe4f2",
+    200: "#ffc9e7",
+    300: "#ff9dd1",
+    400: "#ff60b0",
+    500: "#ff3190",
+    600: "#e60a62",
+    DEFAULT: "#e60a62",
+    700: "#d6004f",
+    800: "#b00441",
+    900: "#92093a",
+    950: "#5a001e",
+  },
 };
 
 module.exports = {


### PR DESCRIPTION
USE SPARINGLY. But the spread looks nice. From uicolors.app: https://uicolors.app/create

Aside: I like the way TailwindCSS designed the `DEFAULT` key syntax. Makes updating this effortless.