### PR TITLE
Add first draft of CV

### DIFF
--- a/src/_data/education.yaml
+++ b/src/_data/education.yaml
@@ -1,0 +1,12 @@
+- institution: Portland State University
+  url: https://www.pdx.edu/
+  dates:
+    start: 1993-06-01
+    end: 2000-06-15
+  description: Bachelor of Arts, Arts and Letters
+- institution: University of Birmingham
+  url: https://www.birmingham.ac.uk/
+  dates:
+    start: 2000-09-01
+    end: 2001-04-01
+  description: Post-graduate study, Computer Science

--- a/src/_data/skills.yaml
+++ b/src/_data/skills.yaml
@@ -19,9 +19,9 @@
   skills:
     - team leadership
     - project management
-    - web standards stewardship
-    - team process management
-    - open-source contributor
+    - standards stewardship
+    - process management
+    - OSS contributor
     - mentorship
 - description: "full-stack web application development"
   skills:
@@ -29,11 +29,11 @@
     - TypeScript
     - python
     - PHP
-    - React/framework du jour
-    - tailwindcss/CSS thingy du jour
-    - embedded systems
+    - React, or
+    - JS framework du jour
+    - tailwindcss, or
+    - CSS thingy du jour
     - API design
-    - CMSes
     - SQL
     - ...etc.
 - description: "software development methodology"

--- a/src/_includes/layouts/cv.njk
+++ b/src/_includes/layouts/cv.njk
@@ -1,0 +1,96 @@
+---
+description: Layout for CV/resume
+layout: layouts/base.njk
+navigationKey: about
+---
+
+{% macro experienceItem(experience) %}
+  {% set eData = experience.data %}
+  <div class="space-y-2">
+    <div>
+      <div class="flex items-center">
+        <h3 class="font-bold md:text-lg lg:text-xl">
+          {{ eData.organization.name }}
+        </h3>
+        <div class="flex-grow text-right italic">
+          <span class="whitespace-nowrap"
+            >{{ eData.tenure.start | formatDate("LLL, yyyy") }}&nbsp;-&nbsp;{{ eData.tenure.end | formatDate("LLL, yyyy") }}</span
+          >
+        </div>
+      </div>
+      <div class="text-sm font-semibold text-pank md:text-base">
+        {{ eData.position }}
+      </div>
+    </div>
+    <div class="prose prose-sm leading-snug md:prose-base md:leading-normal">
+      {{ experience.content | safe }}
+    </div>
+  </div>
+{% endmacro %}
+
+{% macro educationItem(edu) %}
+  <div>
+    <div class="flex items-center gap-x-2">
+      <h3 class="font-bold md:text-lg">
+        <a href="{{ edu.url }}">{{ edu.institution }}</a>
+      </h3>
+
+      <div class="flex-grow text-right italic">
+        {{ edu.dates.start | formatDate("yyyy") }} -
+        {{ edu.dates.end | formatDate("yyyy") }}
+      </div>
+    </div>
+    <div class="text-sm font-semibold text-pank md:text-base">
+      {{ edu.description }}
+    </div>
+  </div>
+{% endmacro %}
+
+<div
+  class="order-last col-span-12 space-y-4 sm:order-first sm:col-span-4 print:space-y-3"
+>
+  <h2 class="border-b font-display lg:text-lg">What I Can Do</h2>
+  <ul class="space-y-2 lg:space-y-4">
+    {% for skillset in skills %}
+      <li
+        class="rounded-lg bg-stone-100 p-2 lg:p-3 print:bg-transparent print:p-0"
+      >
+        <h3
+          class="border-b border-stone-500 pb-1 text-sm font-semibold italic leading-tight text-pank lg:text-base lg:leading-snug print:border-none print:leading-none"
+        >
+          {{ skillset.description }}
+        </h3>
+        <ul
+          class="list-inside list-disc p-2 md:text-lg print:text-sm"
+          style="font-variant-caps:all-small-caps"
+        >
+          {% for skill in skillset.skills %}
+            <li class="marker:text-pank-300 leading-tight print:leading-none">
+              {{ skill }}
+            </li>
+          {% endfor %}
+        </ul>
+      </li>
+    {% endfor %}
+  </ul>
+</div>
+<div class="col-span-12 max-w-none space-y-3 sm:col-span-8 md:space-y-4">
+  <div
+    class="prose prose-sm leading-snug md:prose-lg md:text-justify md:leading-normal"
+  >
+    {{ content | safe }}
+  </div>
+
+  <h2 class="border-b-2 font-display text-lg md:text-2xl">Experience</h2>
+  <ul class="space-y-4">
+    {% for exp in collections.experience | reverse %}
+      <li>{{ experienceItem(exp) }}</li>
+    {% endfor %}
+  </ul>
+  <h2 class="border-b-2 font-display text-xl">Education</h2>
+  <ul class="space-y-4">
+    {% for edu in education | reverse %}
+      <li>{{ educationItem(edu) }}</li>
+    {% endfor %}
+  </ul>
+</div>

--- a/src/cv/experience/bocoup.md
+++ b/src/cv/experience/bocoup.md
@@ -1,0 +1,16 @@
+---
+date: 2016-06-01
+tenure:
+  start: 2016-06-01
+  end: 2017-07-01
+position: Open Web Engineer
+organization:
+  name: Bocoup
+  url: https://bocoup.com/
+  description: >
+    Bocoup partners with tech companies and nonprofits to increase accessibility, inclusion and justice on and through the web.
+---
+
+At Bocoup, I continued in my dedication to support and advocate for the open web platform through open-source contribution, open-source-centric consulting projects, and involvement in web technology standards bodies.
+
+During collaboration with Mozilla on a web-testing project, unearthed a decades-old bug across browsers in the anchor element’s `target` attribute. Built hardware prototypes on LoRA (wide-area, low-power networking) and other embedded systems using open web technologies.

--- a/src/cv/experience/cloudfour.md
+++ b/src/cv/experience/cloudfour.md
@@ -1,0 +1,20 @@
+---
+date: 2007-10-01
+tenure:
+  start: 2007-10-01
+  end: 2016-04-29
+position: Co-founder, CTO
+organization:
+  name: Cloud Four
+  url: https://cloudfour.com/
+  description: >
+    Cloud Four partners with forward-thinking organizations to solve complex web and design system challenges, crafting accessible, responsive and futuristic web experiences.
+---
+
+Cloud Four is a leading web design and development agency that works with organizations to make the most of the modern web through design systems, responsive web design, and progressive web apps. We pioneered the mobile web. Highlights:
+
+- With co-founder Jason Grigsby, literally wrote the book on the mobile web (_Head First Mobile Web_, O'Reilly)
+- Collaborated to build the Obama ’08 iPhone app, one of the earliest apps in the App Store
+- Helped Walmart design responsively
+- Built mobile web apps for clients from Hautelook to local brewery Deschutes
+- Organized and hosted the Responsive Field Day event, attracting speakers and attendees from around the world

--- a/src/cv/experience/experience.11tydata.json
+++ b/src/cv/experience/experience.11tydata.json
@@ -1,0 +1,8 @@
+{
+  "tags": "experience",
+  "tags-works-comment": "make files available in `collections.experience`",
+
+  "permalink": false,
+  "permalint-false-comment": "exclude files from output, only make them available in collections",
+  "permalint-false-docs": "https://www.11ty.dev/docs/permalinks/#permalink-false"
+}

--- a/src/cv/experience/hypothesis.md
+++ b/src/cv/experience/hypothesis.md
@@ -1,0 +1,21 @@
+---
+date: 2018-01-02
+tenure:
+  start: 2018-01-02
+  end: 2023-08-04
+position: Lead Engineer and Technical Project Lead
+organization:
+  name: Hypothesis
+  url: https://hypothes.is
+  description: >
+    Hypothesis’ non-profit mission is to bring a new layer to the Web, enabling anyone to annotate anywhere. Hypothesis’ open-source, web-based software is free to use.
+---
+
+At Hypothesis, I participated in the leadership of a world-class team of technologists, building a product that continually pushed the edges of what was possible to do on the web. Described as the team’s “glue”, I:
+
+- **Synthesized and distilled needs** out of a complex and sometimes-conflicting product landscape into plans for feature design and implementation
+- **Applied broad, multi-disciplinary implementation skills**: empathetic coding, technical design, UI/UX, communication, software workflow, and testing to continually deliver exceptional results.
+- **Brought people together** through project management, mentorship and consensus-driven teamwork. Drove the creation of team engineering values, divining shared values and setting aspirational direction. Refined team processes, such as sprint planning and work cadence.
+- **Got big things _done_**: followed through on big, architectural projects, leading to boosts in performance, reliability and developer velocity.
+- **Brought design thinking and humanity to my work**: designed feature UI; created design systems and built associated library of reusable components; was instrumental in achieving WCAG 2.1 accessibility compliance; reduced CSS payload by 50%.
+- **Retained commitment to open web standards**: aided in design and implementation of APIs conformant to W3C Web Annotation specifications; pushed the edges of web platform APIs.

--- a/src/cv/experience/intel.md
+++ b/src/cv/experience/intel.md
@@ -1,0 +1,12 @@
+---
+date: 2005-01-01
+tenure:
+  start: 2005-01-01
+  end: 2006-04-01
+position: Internal Communications Specialist and Web Developer
+organization:
+  name: Intel
+  url: https://intel.com
+---
+
+Led visual redesign and optimization of Intranet Web site to coincide with new worldwide corporate branding and logo launch. Championed for new media options (RSS, blogging, etc.) and interactivity at dawn of Web 2.0 era. Covered news beats such as mobility and technology standards, and wrote a widely-read biweekly column ("Lyza Log") which explored new and novel technologies.

--- a/src/cv/experience/kavi.md
+++ b/src/cv/experience/kavi.md
@@ -1,0 +1,9 @@
+---
+date: 1997-09-01
+tenure:
+  start: 1997-09-01
+  end: 2007-10-01
+position: Professional Services Web Developer
+organization:
+  name: Kavi
+---

--- a/src/cv/index.md
+++ b/src/cv/index.md
@@ -1,0 +1,6 @@
+---
+title: Lyza Danger Gardner, CV (Resume)
+layout: layouts/cv.njk
+---
+
+I have over 25 years of experience with the open Web platform, including stewardship, implementation, writing, consulting, speaking and team leadership. I understand how the Web works and my work is united by open-source web technologies and stellar colleagues. I’m motivated by figuring things out, building things and synthesizing complex information into written or spoken form.


### PR DESCRIPTION
This PR adds a first draft of a CV/resume page at `/cv`.

What's done so far:

* Basic content is in place, including experience and skills and education
* Layout established and responsive design across breakpoints
* Print styles applied and prints in two pages

This is not linked from anywhere as, while it's valid, it's incomplete and not ready for prime time.

<img src="https://github.com/lyzadanger/lyza-dot-11ty/assets/439947/5c319ac1-0f0a-4431-a930-c1eba663c5ef" width="400" />
