### PR TITLE
Perform some 11ty tag consolidation

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -57,7 +57,7 @@ module.exports = function (eleventyConfig) {
   });
 
   // These tags should not be shown when rendering blog-post tags
-  const excludedPostTags = ["post", "posts"];
+  const excludedPostTags = ["all", "posts"];
 
   const filterTags = (itemTags, disallowedTags = excludedPostTags) => {
     return itemTags.filter((tag) => !disallowedTags.includes(tag));

--- a/.eleventy.js
+++ b/.eleventy.js
@@ -56,15 +56,23 @@ module.exports = function (eleventyConfig) {
     return DateTime.fromJSDate(dateObj).toFormat(format);
   });
 
+  // These tags should not be shown when rendering blog-post tags
+  const excludedPostTags = ["post", "posts"];
+
+  const filterTags = (itemTags, disallowedTags = excludedPostTags) => {
+    return itemTags.filter((tag) => !disallowedTags.includes(tag));
+  };
+
+  // Filter out excludedPostTags from an array of tags
+  eleventyConfig.addFilter("postTags", filterTags);
+
   // Custom filter: Return all the tags used in a collection, with counts
   // of how many items in the collection use each tag, sorted by count desc
   eleventyConfig.addFilter("getAllTagsWithCount", (collection) => {
     const tags = [];
     for (let item of collection) {
-      (item.data.tags || []).forEach((tag) => {
-        if (tag === "post") {
-          return;
-        }
+      const postTags = filterTags(item.data.tags || []);
+      postTags.forEach((tag) => {
         const existingTag = tags.find((el) => el.tag === tag);
         if (existingTag) {
           existingTag.count++;

--- a/src/_includes/components/post-summary.njk
+++ b/src/_includes/components/post-summary.njk
@@ -9,15 +9,13 @@
       </h4>
       <div class="flex-grow">
         <ul class="flex flex-row justify-end gap-2 font-title">
-          {% for tag in post.data.tags %}
-            {% if tag != 'post' %}
-              <li
-                class="text-lg text-grey-600 hover:text-pank"
-                style="font-variant-caps: all-small-caps"
-              >
-                <a href="/tags/{{ tag | slugify }}">#{{ tag }}</a>
-              </li>
-            {% endif %}
+          {% for tag in post.data.tags | postTags %}
+            <li
+              class="text-lg text-grey-600 hover:text-pank"
+              style="font-variant-caps: all-small-caps"
+            >
+              <a href="/tags/{{ tag | slugify }}">#{{ tag }}</a>
+            </li>
           {% endfor %}
         </ul>
       </div>

--- a/src/_includes/layouts/blog-post.njk
+++ b/src/_includes/layouts/blog-post.njk
@@ -14,15 +14,14 @@ navigationKey: posts
       <div class="prose prose-lg italic">{{ excerpt }}</div>
     </div>
     <ul class="flex flex-row gap-2 font-title">
-      {% for tag in tags %}
-        {% if tag != 'posts' %}
-          <li
-            class="text-lg text-grey-600 hover:text-pank"
-            style="font-variant-caps: all-small-caps"
-          >
-            <a href="/tags/{{ tag | slugify }}">#{{ tag }}</a>
-          </li>
-        {% endif %}
+      {% set postTags = tags | postTags %}
+      {% for tag in postTags %}
+        <li
+          class="text-lg text-grey-600 hover:text-pank"
+          style="font-variant-caps: all-small-caps"
+        >
+          <a href="/tags/{{ tag | slugify }}">#{{ tag }}</a>
+        </li>
       {% endfor %}
     </ul>
   </div>

--- a/src/_includes/layouts/blog.njk
+++ b/src/_includes/layouts/blog.njk
@@ -23,10 +23,10 @@ navigationKey: posts
             {% if not activeTag %}
               aria-current="page"
             {% endif %}
-            >All Posts ({{ collections.post.length }})</a
+            >All Posts ({{ collections.posts.length }})</a
           >
         </li>
-        {% set postTags = collections.post | getAllTagsWithCount %}
+        {% set postTags = collections.posts | getAllTagsWithCount %}
         {% for tag in postTags %}
           <li class="font-title">
             <a

--- a/src/_includes/layouts/home.njk
+++ b/src/_includes/layouts/home.njk
@@ -76,7 +76,7 @@ navigationKey: about
     The latest
   </h2>
   <div class="space-y-2 md:col-span-9 lg:col-span-10">
-    {% set latestPost = collections.post | last %}
+    {% set latestPost = collections.posts | last %}
     {% if latestPost %}
       <div class="border-b">
         <h3 class="font-display md:text-lg">

--- a/src/blog.njk
+++ b/src/blog.njk
@@ -2,7 +2,7 @@
 layout: layouts/blog.njk
 title: Bloggy-posties
 pagination:
-  data: collections.post
+  data: collections.posts
   size: 12
   reverse: true
 ---

--- a/src/content/posts/archive/edge-conf-london-june-2015.md
+++ b/src/content/posts/archive/edge-conf-london-june-2015.md
@@ -1,6 +1,5 @@
 ---
 title: "Edge Conf London, June 2015"
-template: post
 tags:
   - tech
   - standards

--- a/src/content/posts/archive/i-am-unafraid-of-times-new-roman.md
+++ b/src/content/posts/archive/i-am-unafraid-of-times-new-roman.md
@@ -1,6 +1,5 @@
 ---
 title: Unafraid of Times New Roman
-template: post
 tags:
   - lyza-dot-com
   - tech

--- a/src/content/posts/archive/lyzas-index-july-30.md
+++ b/src/content/posts/archive/lyzas-index-july-30.md
@@ -3,7 +3,6 @@ title: "Lyza's Index: July 30"
 tags:
   - life
   - til
-template: post
 date: "2015-07-30T23:12:59.176Z"
 excerpt: In which I mention a few things I learned.
 ---

--- a/src/content/posts/archive/the-rajneeshees-another-sign-i-am-a-portland-native.md
+++ b/src/content/posts/archive/the-rajneeshees-another-sign-i-am-a-portland-native.md
@@ -1,6 +1,5 @@
 ---
 title: "The Rajneeshees: Another Sign I am a Portland Native"
-template: post
 tags:
   - oregon
   - life

--- a/src/content/posts/posts.11tydata.js
+++ b/src/content/posts/posts.11tydata.js
@@ -1,5 +1,5 @@
 module.exports = {
-  tags: "post",
+  tags: "posts",
   layout: "layouts/blog-post.njk",
   permalink: "/{{ page.date | date: '%Y/%m/%d' }}/{{ page.fileSlug }}/",
   "tags-works-comment": "make files available in `collections.posts`",

--- a/src/feeds/feed.njk
+++ b/src/feeds/feed.njk
@@ -3,5 +3,5 @@
 permalink: /feeds/rss.rss
 ---
 
-{% set items = collections.post %}
+{% set items = collections.posts %}
 {% include 'components/rss.njk' %}

--- a/src/tags.html
+++ b/src/tags.html
@@ -5,7 +5,6 @@ pagination:
   alias: activeTag
   filter:
     - all
-    - post
     - posts
     - tagList
   addAllPagesToCollections: true


### PR DESCRIPTION
This PR addresses some tech-debt and bug tasks related to post tags in 11ty. This includes:

* Using `'posts'` instead of `'post'` for the blog post collection tag
* Abstracting post-tag filtering a little
* Fixing a bug in RSS feeds via the first item in this list
* Removing some crufty front-matter I found in blog-post content