### PR TITLE
Add support for series feature

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -57,10 +57,20 @@ module.exports = function (eleventyConfig) {
   });
 
   // These tags should not be shown when rendering blog-post tags
-  const excludedPostTags = ["all", "posts"];
+  const excludedPostTags = ["all", "posts", /^series/];
 
   const filterTags = (itemTags, disallowedTags = excludedPostTags) => {
-    return itemTags.filter((tag) => !disallowedTags.includes(tag));
+    return itemTags.filter((tag) => {
+      for (const disallowed of disallowedTags) {
+        // string comparison being speedier than `.match` if it's not a RegExp
+        if (typeof disallowed === "string" && tag === disallowed) {
+          return false;
+        } else if (tag.match(disallowed)) {
+          return false;
+        }
+      }
+      return true;
+    });
   };
 
   // Filter out excludedPostTags from an array of tags

--- a/.eleventy.js
+++ b/.eleventy.js
@@ -76,6 +76,29 @@ module.exports = function (eleventyConfig) {
   // Filter out excludedPostTags from an array of tags
   eleventyConfig.addFilter("postTags", filterTags);
 
+  // Return the series tag representing the series that this item belongs to, if
+  // any. Throw if the item belongs to multiple series, as that is not currently
+  // allowed.
+  // NB: This function cannot be an arrow function because of necessary
+  // `this` binding.
+  eleventyConfig.addFilter("seriesSlug", function (tags) {
+    const seriesTags = (tags || []).filter((tag) => tag.match(/^series/));
+    if (!seriesTags.length) {
+      return false;
+    }
+    if (seriesTags.length > 1) {
+      throw new Error(
+        `Item may only belong to one series. File at '${this.page.inputPath}' has multiple series tags`,
+      );
+    }
+    return seriesTags[0].replace("series-", "");
+  });
+
+  // Look up a series data object in `seriesData` by slug
+  eleventyConfig.addFilter("getSeriesBySlug", (seriesData, slug) =>
+    seriesData.find((item) => item.slug == slug),
+  );
+
   // Custom filter: Return all the tags used in a collection, with counts
   // of how many items in the collection use each tag, sorted by count desc
   eleventyConfig.addFilter("getAllTagsWithCount", (collection) => {

--- a/src/_includes/components/post-summary.njk
+++ b/src/_includes/components/post-summary.njk
@@ -1,8 +1,11 @@
 <div class="flex flex-col gap-y-1 border-t-3 border-solid border-grey-900">
   <div>
     <a href="{{ post.page.url }}" class="hover:text-pank">
-      <h3 class="font-display text-xl">{{ post.data.title }}</h3>
+      {% if post.data.title %}
+        <h3 class="font-display text-xl">{{ post.data.title }}</h3>
+      {% endif %}
     </a>
+
     <div class="flex items-center gap-x-1 border-b">
       <h4 class="text-l font-display font-normal italic">
         {{ post.date | localeDate }}
@@ -20,7 +23,9 @@
         </ul>
       </div>
     </div>
+  </div>
 
-    <div class="font-body text-grey-700">{{ post.data.excerpt }}</div>
+  <div class="font-body text-grey-700">
+    {% if post.data.excerpt %}{{ post.data.excerpt }}{% endif %}
   </div>
 </div>

--- a/src/_includes/layouts/blog-post.njk
+++ b/src/_includes/layouts/blog-post.njk
@@ -29,9 +29,79 @@ navigationKey: posts
 {# Set min-width and overflow to prevent code block blowouts.
  #  See https://stackoverflow.com/questions/55738093/prismjs-not-overflowing-with-css-grid
  #}
-<main
-  class="prose col-span-12 min-w-0 overflow-auto md:col-span-8 md:pl-4"
-  id="skip"
->
-  {{ content }}
+<main class="col-span-12 min-w-0 overflow-auto md:col-span-8 md:pl-4" id="skip">
+  {% set seriesSlug = tags | seriesSlug %}
+  {% if seriesSlug %}
+    {% set seriesPosts = collections['series-' + seriesSlug] %}
+    {% set activeSeries = series | getSeriesBySlug(seriesSlug) %}
+    <nav
+      class="mb-6 flex w-full flex-col
+  sm:float-right sm:my-2 sm:ml-4 sm:w-1/2 sm:min-w-0"
+    >
+      <div
+        class="border-b py-1 font-display text-lg sm:border-y sm:border-t-2 sm:p-1"
+      >
+        <span class="text-pank">Series</span> /
+        <a
+          class="not-prose transition-colors hover:text-pank hover:underline"
+          href="/series/{{ seriesSlug }}"
+          >{{ activeSeries.title }}</a
+        >
+      </div>
+      <p class="my-2 italic leading-snug md:text-sm">
+        {{ activeSeries.description }}
+      </p>
+
+      <div class="prose">
+        <ol class="mt-0 border-b pb-1 leading-snug sm:text-sm">
+          {% for seriesPost in seriesPosts %}
+            <li>
+              <a
+                href="{{ seriesPost.url }}"
+                class="{% if seriesPost.url == page.url %}
+                  text-grey-700 no-underline font-semibold
+                {% endif %} transition-colors hover:text-pank hover:underline"
+                {% if seriesPost.url == page.url %}aria-current="page"{% endif %}
+                >{{ seriesPost.data.title }}
+              </a>
+            </li>
+          {% endfor %}
+        </ol>
+      </div>
+    </nav>
+  {% endif %}
+  <div class="prose">{{ content }}</div>
 </main>
+<div class="col-span-12 max-w-none space-y-4">
+  {% if seriesSlug %}
+    {% set nextPost = seriesPosts | getNextCollectionItem(page) %}
+    {% set prevPost = seriesPosts | getPreviousCollectionItem(page) %}
+    <hr class="border-t border-stone-200 md:mx-4" />
+    <div class="text-center md:text-xl">
+      <span class="font-display text-pank">Series</span> /
+      <span class="font-display"
+        ><a
+          class="transition-colors hover:text-pank hover:underline"
+          href="/series/{{ seriesSlug }}"
+          >{{ activeSeries.title }}</a
+        ></span
+      >
+    </div>
+    <div class="prose flex max-w-none items-start gap-x-2 leading-none">
+      {% if prevPost %}
+        <div>«</div>
+        <div class="text-left leading-tight">
+          <div class="sr-only italic sm:not-sr-only">Previous in series:</div>
+          <a href="{{ prevPost.url }}">{{ prevPost.data.title }}</a>
+        </div>
+      {% endif %}
+      {% if nextPost %}
+        <div class="flex-grow text-right leading-tight">
+          <div class="sr-only italic sm:not-sr-only">Next in series:</div>
+          <a href="{{ nextPost.url }}">{{ nextPost.data.title }}</a>
+        </div>
+        <div>»</div>
+      {% endif %}
+    </div>
+  {% endif %}
+</div>

--- a/src/series.njk
+++ b/src/series.njk
@@ -1,0 +1,42 @@
+---
+pagination:
+  data: series
+  size: 1
+  alias: activeSeries
+  addAllPagesToCollections: true
+layout: layouts/base.njk
+eleventyComputed:
+  title: "Series: “{{ activeSeries.title }}”"
+permalink: /series/{{ activeSeries.slug | slugify }}/
+navigationKey: posts
+---
+
+{% set seriesItems = collections['series-' + activeSeries.slug] %}
+
+<div class="col-span-12 space-y-4 md:col-span-4">
+  <div class="static space-y-2 md:sticky md:top-0">
+    <div class="border-b py-2 font-display md:pt-0">
+      <h1 class="text-xl">
+        <span class="text-pank">Series</span> / {{ activeSeries.title }}
+      </h1>
+    </div>
+    <div class="border-b pb-2">
+      <div class="prose prose-lg italic">{{ activeSeries.description }}</div>
+    </div>
+  </div>
+</div>
+<div class="col-span-12 md:col-span-8">
+  <ol class="ml-4 space-y-8 pl-8 [counter-reset:section] md:ml-8">
+    {%- for post in seriesItems -%}
+      <li
+        class="relative font-sans [counter-increment:section] before:absolute before:-left-12 before:top-3 before:flex before:min-h-8 before:min-w-8 before:items-center
+        before:justify-center before:rounded-full before:bg-pank before:text-center before:text-xl before:font-semibold before:leading-none before:text-white before:content-[counters(section,'.')]"
+      >
+        {%
+          include
+          "components/post-summary.njk"
+        %}
+      </li>
+    {%- endfor -%}
+  </ol>
+</div>

--- a/src/tags.njk
+++ b/src/tags.njk
@@ -10,12 +10,12 @@ pagination:
   addAllPagesToCollections: true
 layout: layouts/blog.njk
 eleventyComputed:
-  title: Posts tagged “{{ activeTag }}”
+  title: "Posts tagged '{{ activeTag }}'"
 permalink: /tags/{{ activeTag | slugify }}/
 ---
 
 <ul class="space-y-8">
-  {% for post in collections[activeTag] reversed %}
-  <li>{% include "components/post-summary.njk" %}</li>
+  {% for post in collections[activeTag] | reverse %}
+    <li>{% include "components/post-summary.njk" %}</li>
   {% endfor %}
 </ul>


### PR DESCRIPTION
This PR adds the primary support functionality for the series feature, but no series content or metadata. There are no user-visible changes at this time.

The `series.yaml` metadata file is intended to contain an array of series objects, which each have a `slug`, `title` and `description` (I miss types so hard).

To add a blog post series, add a corresponding data object to the `series.yaml` file. A page for the series will be output at `/series/{series-slug}`, showing and linking to all of the posts in the series.

To add posts to a series, add a tag to those posts' front-matter/metadata following the pattern `series-{series-slug}`. A post may only belong to one series at this time. If more than one series tag is added, it will throw and tell you about it.

When viewing a blog post that is in a series, one will see a "table-of-contents"-style navigation near the top of the blog post and previous/next navigation at the bottom. 

Fixes #24
Fixes #33 
Fixes #34

## Example: "Lyza.com History" series

I have another branch that:

* Adds a series entry to the `series.yaml` file slugged as `lyza-dot-com-history` and
* Tags three blog posts with `series-lyza-dot-com-history` (note that these `series-*` tags are filtered out when rendering lists of tags for posts)

If I rebase that branch on this branch, this is what we get.

### Series landing page

A series landing page (shown here at various viewport sizes):

<img width="461" alt="image" src="https://github.com/lyzadanger/lyza-dot-11ty/assets/439947/9287d89e-0d30-480e-9d55-d763c612fca3">

<img width="1093" alt="image" src="https://github.com/lyzadanger/lyza-dot-11ty/assets/439947/8789b618-0801-46c9-9047-569d98aae3a8">

### Navigation within blog posts in the series

#### Table-of-content style navigation near top of post

<img width="456" alt="image" src="https://github.com/lyzadanger/lyza-dot-11ty/assets/439947/09db8af2-b91e-4ddd-aa2c-a4578d90089c">

<img width="1089" alt="image" src="https://github.com/lyzadanger/lyza-dot-11ty/assets/439947/cd50a0b9-070c-4ece-8f4d-0197d8fa378f">


#### Previous/next navigation at bottom of post

<img width="515" alt="image" src="https://github.com/lyzadanger/lyza-dot-11ty/assets/439947/48f1a464-cd2a-4182-91a6-fc0a67e5cc08">


<img width="1130" alt="image" src="https://github.com/lyzadanger/lyza-dot-11ty/assets/439947/6bbe7157-28e2-4ae8-9cab-de4c1c2c842f">
