### PR TITLE
Consolidate styling and fix small design issues

### DIFF
--- a/src/404.njk
+++ b/src/404.njk
@@ -4,7 +4,7 @@ title: "404: Not Found"
 layout: layouts/page.njk
 ---
 
-<div class="prose col-span-12 max-w-none text-center">
+<div class="prose prose-stone col-span-12 max-w-none text-center">
   <h1>Sorry! Not Found (404)</h1>
   <p class="text-xl">
     Bah. What you are looking for here doesn't seem to exist. Sorry about that!

--- a/src/_includes/components/book.njk
+++ b/src/_includes/components/book.njk
@@ -1,5 +1,5 @@
 <div class="border-b border-t-3 border-grey-800 py-2">
-  <h3 class="text-center font-display text-sky-800">
+  <h3 class="text-center font-display text-blue-800">
     <a
       href="{{ book.url }}"
       class="transition-colors group-hover:text-pank group-hover:underline"

--- a/src/_includes/components/navigation.njk
+++ b/src/_includes/components/navigation.njk
@@ -1,30 +1,26 @@
+{% macro topNavLink(href, title, key, navigationKey) %}
+  <a
+    href="{{ href }}"
+    style="font-variant-caps: all-small-caps"
+    {% if navigationKey == key %}
+      aria-current="page"
+    {% endif %}
+    class="{% if navigationKey == key %}italic{% endif %} pt-2.5 font-title text-2xl font-light text-grey-700 transition-colors hover:text-pank"
+    >{{ title }}</a
+  >
+{% endmacro %}
+
+{% macro topNavItem(href, title, key, navigationKey) %}
+  <li
+    class="{% if navigationKey == key %}border-pank{% else %}border-transparent{% endif %} border-b-10 pt-2.5"
+  >
+    {{ topNavLink(href, title, key, navigationKey) }}
+  </li>
+{% endmacro %}
+
 <nav class="print:hidden">
   <ul class="flex flex-row gap-4 justify-self-stretch sm:gap-6">
-    <li
-      class="{% if navigationKey == 'about' %}border-pank{% else %}border-transparent{% endif %} border-b-10 pt-2.5"
-    >
-      <a
-        href="/"
-        style="font-variant-caps: all-small-caps"
-        class="{% if navigationKey == 'about' %}italic{% endif %} pt-2.5 font-title text-2xl font-light text-grey-700 hover:text-pank"
-        {% if navigationKey == 'about' %}
-          aria-current="page"
-        {% endif %}
-        >About</a
-      >
-    </li>
-    <li
-      class="{% if navigationKey == 'posts' %}border-pank{% else %}border-transparent{% endif %} border-b-10 pt-2.5"
-    >
-      <a
-        href="/blog"
-        style="font-variant-caps: all-small-caps"
-        class="{% if navigationKey == 'posts' %}italic{% endif %} pt-2.5 font-title text-2xl font-light text-grey-700 hover:text-pank"
-        {% if navigationKey == 'posts' %}
-          aria-current="page"
-        {% endif %}
-        >Blog</a
-      >
-    </li>
+    {{ topNavItem('/', 'About', 'about', navigationKey) }}
+    {{ topNavItem('/blog', 'Blog', 'posts', navigationKey) }}
   </ul>
 </nav>

--- a/src/_includes/components/post-summary.njk
+++ b/src/_includes/components/post-summary.njk
@@ -2,7 +2,10 @@
   class="border-t-3 border-solid border-grey-900 sm:flex sm:flex-col sm:gap-y-1"
 >
   <div>
-    <a href="{{ post.page.url }}" class="hover:text-pank">
+    <a
+      href="{{ post.page.url }}"
+      class="transition-colors hover:text-pank hover:underline"
+    >
       {% if post.data.title %}
         <h3 class="font-display text-xl">{{ post.data.title }}</h3>
       {% endif %}
@@ -16,10 +19,14 @@
         <ul class="flex flex-row gap-2 font-title sm:justify-end">
           {% for tag in post.data.tags | postTags %}
             <li
-              class="text-lg text-grey-600 hover:text-pank"
+              class="text-lg text-grey-600"
               style="font-variant-caps: all-small-caps"
             >
-              <a href="/tags/{{ tag | slugify }}">#{{ tag }}</a>
+              <a
+                class="transition-colors hover:text-pank"
+                href="/tags/{{ tag | slugify }}"
+                >#{{ tag }}</a
+              >
             </li>
           {% endfor %}
         </ul>

--- a/src/_includes/components/post-summary.njk
+++ b/src/_includes/components/post-summary.njk
@@ -1,4 +1,6 @@
-<div class="flex flex-col gap-y-1 border-t-3 border-solid border-grey-900">
+<div
+  class="border-t-3 border-solid border-grey-900 sm:flex sm:flex-col sm:gap-y-1"
+>
   <div>
     <a href="{{ post.page.url }}" class="hover:text-pank">
       {% if post.data.title %}
@@ -6,12 +8,12 @@
       {% endif %}
     </a>
 
-    <div class="flex items-center gap-x-1 border-b">
-      <h4 class="text-l font-display font-normal italic">
+    <div class="border-b sm:flex sm:items-center sm:gap-x-1">
+      <h4 class="text-l whitespace-nowrap font-display font-normal italic">
         {{ post.date | localeDate }}
       </h4>
-      <div class="flex-grow">
-        <ul class="flex flex-row justify-end gap-2 font-title">
+      <div class="sm:flex-grow">
+        <ul class="flex flex-row gap-2 font-title sm:justify-end">
           {% for tag in post.data.tags | postTags %}
             <li
               class="text-lg text-grey-600 hover:text-pank"

--- a/src/_includes/components/work.njk
+++ b/src/_includes/components/work.njk
@@ -4,7 +4,10 @@
   <div class="flex h-full flex-col border-b border-b-grey-800">
     <h2 class="flex-grow font-display text-lg leading-snug">
       {% if work.data.url %}
-        <a href="{{ work.data.url }}" class="hover:text-pank hover:underline">
+        <a
+          href="{{ work.data.url }}"
+          class="transition-colors hover:text-pank hover:underline"
+        >
           {{ work.data.title }}
         </a>
       {% else %}

--- a/src/_includes/components/work.njk
+++ b/src/_includes/components/work.njk
@@ -35,6 +35,8 @@
     {% endif %}
   </div>
   <div>
-    <div class="prose flex-grow leading-normal">{{ work.content }}</div>
+    <div class="prose prose-stone flex-grow leading-normal">
+      {{ work.content }}
+    </div>
   </div>
 </div>

--- a/src/_includes/layouts/base.njk
+++ b/src/_includes/layouts/base.njk
@@ -168,7 +168,7 @@ description: base layout for site
           <div class="mt-px h-4 w-4">
             <a
               href="https://github.com/lyzadanger/lyza-dot-11ty"
-              class="text-stone-700 group-hover:text-pank"
+              class="text-grey-700 group-hover:text-pank"
             >
               {%- include 'icons/github.njk' -%}
             </a>

--- a/src/_includes/layouts/base.njk
+++ b/src/_includes/layouts/base.njk
@@ -70,7 +70,9 @@ description: base layout for site
   </head>
   <body class="mx-4 font-body">
     <a href="#skip" class="sr-only">Skip to main content</a>
-    <div class="mx-auto my-2 max-w-5xl space-y-6 md:my-8 md:space-y-8">
+    <div
+      class="mx-auto flex min-h-[100vh] max-w-5xl flex-col space-y-6 py-2 md:space-y-8 md:py-8"
+    >
       <header
         role="banner"
         class="grid grid-cols-3 items-center gap-x-8 border-b-2 border-t border-grey-900"
@@ -137,7 +139,9 @@ description: base layout for site
         </div>
       </header>
 
-      <div class="grid grid-cols-12 gap-x-4 gap-y-6 md:gap-y-12 lg:gap-y-16">
+      <div
+        class="grid flex-grow grid-cols-12 gap-x-4 gap-y-6 md:gap-y-12 lg:gap-y-16"
+      >
         {{ content | safe }}
       </div>
 

--- a/src/_includes/layouts/base.njk
+++ b/src/_includes/layouts/base.njk
@@ -152,23 +152,23 @@ description: base layout for site
         <div class="flex gap-x-2 px-2">
           <div>
             Built by Lyza with
-            <a href="https://www.11ty.dev/" class="text-pank hover:underline"
+            <a
+              href="https://www.11ty.dev/"
+              class="text-pank transition-colors hover:underline"
               >Eleventy</a
             >
           </div>
         </div>
-        <div
-          class="group flex items-center gap-x-2 border-l px-2 transition-colors"
-        >
+        <div class="group flex items-center gap-x-2 border-l px-2">
           <a
             href="https://github.com/lyzadanger/lyza-dot-11ty"
-            class="group-hover:text-pank group-hover:underline"
+            class="transition-colors group-hover:text-pank group-hover:underline"
             >Source</a
           >
           <div class="mt-px h-4 w-4">
             <a
               href="https://github.com/lyzadanger/lyza-dot-11ty"
-              class="text-grey-700 group-hover:text-pank"
+              class="text-grey-700 transition-colors group-hover:text-pank"
             >
               {%- include 'icons/github.njk' -%}
             </a>

--- a/src/_includes/layouts/blog-post.njk
+++ b/src/_includes/layouts/blog-post.njk
@@ -16,11 +16,12 @@ navigationKey: posts
     <ul class="flex flex-row gap-2 font-title">
       {% set postTags = tags | postTags %}
       {% for tag in postTags %}
-        <li
-          class="text-lg text-grey-600 hover:text-pank"
-          style="font-variant-caps: all-small-caps"
-        >
-          <a href="/tags/{{ tag | slugify }}">#{{ tag }}</a>
+        <li style="font-variant-caps: all-small-caps">
+          <a
+            href="/tags/{{ tag | slugify }}"
+            class="text-lg text-grey-600 transition-colors hover:text-pank hover:underline"
+            >#{{ tag }}</a
+          >
         </li>
       {% endfor %}
     </ul>

--- a/src/_includes/layouts/blog-post.njk
+++ b/src/_includes/layouts/blog-post.njk
@@ -11,7 +11,7 @@ navigationKey: posts
       <h4 class="italic">{{ page.date | localeDate }}</h4>
     </div>
     <div class="border-b pb-2">
-      <div class="prose prose-lg italic">{{ excerpt }}</div>
+      <div class="prose prose-lg prose-stone italic">{{ excerpt }}</div>
     </div>
     <ul class="flex flex-row gap-2 font-title">
       {% set postTags = tags | postTags %}
@@ -52,7 +52,7 @@ navigationKey: posts
         {{ activeSeries.description }}
       </p>
 
-      <div class="prose">
+      <div class="prose prose-stone">
         <ol class="mt-0 border-b pb-1 leading-snug sm:text-sm">
           {% for seriesPost in seriesPosts %}
             <li>
@@ -70,7 +70,7 @@ navigationKey: posts
       </div>
     </nav>
   {% endif %}
-  <div class="prose">{{ content }}</div>
+  <div class="prose prose-stone">{{ content }}</div>
 </main>
 <div class="col-span-12 max-w-none space-y-4">
   {% if seriesSlug %}
@@ -87,7 +87,9 @@ navigationKey: posts
         ></span
       >
     </div>
-    <div class="prose flex max-w-none items-start gap-x-2 leading-none">
+    <div
+      class="prose prose-stone flex max-w-none items-start gap-x-2 leading-none"
+    >
       {% if prevPost %}
         <div>«</div>
         <div class="text-left leading-tight">

--- a/src/_includes/layouts/blog-post.njk
+++ b/src/_includes/layouts/blog-post.njk
@@ -76,7 +76,7 @@ navigationKey: posts
   {% if seriesSlug %}
     {% set nextPost = seriesPosts | getNextCollectionItem(page) %}
     {% set prevPost = seriesPosts | getPreviousCollectionItem(page) %}
-    <hr class="border-t border-stone-200 md:mx-4" />
+    <hr class="border-t border-grey-200 md:mx-4" />
     <div class="text-center md:text-xl">
       <span class="font-display text-pank">Series</span> /
       <span class="font-display"

--- a/src/_includes/layouts/blog.njk
+++ b/src/_includes/layouts/blog.njk
@@ -5,6 +5,21 @@ description: >
 navigationKey: posts
 ---
 
+{% macro tagLink(tag, tagCount, activeTag) %}
+  {% set _activeTag = 'all' if not activeTag else activeTag %}
+  <a
+    href="{% if tag == 'all' %}/blog/{% else %}/tags/{{ tag | slugify }}{% endif %}"
+    class="{% if tag == _activeTag %}
+      text-pank italic border-l-3 border-pank font-semibold
+    {% endif %} pl-2 transition-colors hover:text-pank"
+    {% if tag == _activeTag %}
+      aria-current="page"
+    {% endif %}
+  >
+    {{ 'All Posts' if tag == 'all' else tag }}&nbsp;({{ tagCount }})</a
+  >
+{% endmacro %}
+
 <div class="col-span-12 md:col-span-4">
   <div>
     <h3 class="border-b pb-2 font-display text-xl">Posts by Tag</h3>
@@ -13,35 +28,12 @@ navigationKey: posts
     >
       <ul>
         <li class="font-title">
-          <a
-            href="/blog"
-            class="
-            {% if not activeTag %}
-              text-pank italic border-l-3 border-pank font-semibold
-            {% endif %} pl-2 hover:text-pank
-          "
-            {% if not activeTag %}
-              aria-current="page"
-            {% endif %}
-            >All Posts ({{ collections.posts.length }})</a
-          >
+          {{ tagLink('all', collections.posts.length, activeTag) }}
         </li>
         {% set postTags = collections.posts | getAllTagsWithCount %}
         {% for tag in postTags %}
           <li class="font-title">
-            <a
-              href="/tags/{{ tag.tag | slugify }}"
-              class="
-              {% if tag.tag == activeTag %}
-                text-pank italic border-l-3 border-pank font-semibold
-              {% endif %} pl-2 hover:text-pank
-            "
-              {% if tag.tag == activeTag %}
-                aria-current="page"
-              {% endif %}
-            >
-              {{- tag.tag -}} &nbsp;({{ tag.count }})</a
-            >
+            {{ tagLink(tag.tag, tag.count, activeTag) }}
           </li>
         {% endfor %}
       </ul>

--- a/src/_includes/layouts/cv.njk
+++ b/src/_includes/layouts/cv.njk
@@ -22,7 +22,9 @@ navigationKey: about
         {{ eData.position }}
       </div>
     </div>
-    <div class="prose prose-sm leading-snug md:prose-base md:leading-normal">
+    <div
+      class="prose prose-sm prose-stone leading-snug md:prose-base md:leading-normal"
+    >
       {{ experience.content | safe }}
     </div>
   </div>
@@ -65,7 +67,7 @@ navigationKey: about
           style="font-variant-caps:all-small-caps"
         >
           {% for skill in skillset.skills %}
-            <li class="marker:text-pank-300 leading-tight print:leading-none">
+            <li class="leading-tight marker:text-pank-300 print:leading-none">
               {{ skill }}
             </li>
           {% endfor %}
@@ -76,7 +78,7 @@ navigationKey: about
 </div>
 <div class="col-span-12 max-w-none space-y-3 sm:col-span-8 md:space-y-4">
   <div
-    class="prose prose-sm leading-snug md:prose-lg md:text-justify md:leading-normal"
+    class="prose prose-sm prose-stone leading-snug md:prose-lg md:text-justify md:leading-normal"
   >
     {{ content | safe }}
   </div>

--- a/src/_includes/layouts/cv.njk
+++ b/src/_includes/layouts/cv.njk
@@ -55,10 +55,10 @@ navigationKey: about
   <ul class="space-y-2 lg:space-y-4">
     {% for skillset in skills %}
       <li
-        class="rounded-lg bg-stone-100 p-2 lg:p-3 print:bg-transparent print:p-0"
+        class="rounded-lg bg-grey-100 p-2 lg:p-3 print:bg-transparent print:p-0"
       >
         <h3
-          class="border-b border-stone-500 pb-1 text-sm font-semibold italic leading-tight text-pank lg:text-base lg:leading-snug print:border-none print:leading-none"
+          class="border-b border-grey-500 pb-1 text-sm font-semibold italic leading-tight text-pank lg:text-base lg:leading-snug print:border-none print:leading-none"
         >
           {{ skillset.description }}
         </h3>

--- a/src/_includes/layouts/cv.njk
+++ b/src/_includes/layouts/cv.njk
@@ -34,7 +34,11 @@ navigationKey: about
   <div>
     <div class="flex items-center gap-x-2">
       <h3 class="font-bold md:text-lg">
-        <a href="{{ edu.url }}">{{ edu.institution }}</a>
+        <a
+          href="{{ edu.url }}"
+          class="transition-colors hover:text-pank hover:underline"
+          >{{ edu.institution }}</a
+        >
       </h3>
 
       <div class="flex-grow text-right italic">

--- a/src/_includes/layouts/home.njk
+++ b/src/_includes/layouts/home.njk
@@ -20,12 +20,14 @@ navigationKey: about
 
 {% macro iconLink(url, title, icon) %}
   <li
-    class="group text-xl font-light leading-none transition-colors"
+    class="group text-xl font-light leading-none"
     style="font-variant-caps:all-small-caps"
   >
     <a href="{{ url }}">
       <div class="flex items-center gap-x-2 md:gap-x-3">
-        <div class="h-4 w-4 text-grey-700 group-hover:text-pank">
+        <div
+          class="h-4 w-4 text-grey-700 transition-colors group-hover:text-pank"
+        >
           {% if icon %}{% include "icons/" + icon + ".njk" %}{% endif %}
         </div>
         <div

--- a/src/_includes/layouts/home.njk
+++ b/src/_includes/layouts/home.njk
@@ -92,14 +92,14 @@ navigationKey: about
       </div>
       <div>
         <a
-          class="text-sky-800 underline transition-colors hover:text-pank"
+          class="text-blue-800 underline transition-colors hover:text-pank"
           href="{{ latestPost.url }}"
           >Read More</a
         >
         |
         <a
           href="/blog"
-          class="text-sky-800 underline transition-colors hover:text-pank"
+          class="text-blue-800 underline transition-colors hover:text-pank"
           >All blog posts</a
         >
       </div>

--- a/src/_includes/layouts/home.njk
+++ b/src/_includes/layouts/home.njk
@@ -25,7 +25,7 @@ navigationKey: about
   >
     <a href="{{ url }}">
       <div class="flex items-center gap-x-2 md:gap-x-3">
-        <div class="h-4 w-4 text-stone-700 group-hover:text-pank">
+        <div class="h-4 w-4 text-grey-700 group-hover:text-pank">
           {% if icon %}{% include "icons/" + icon + ".njk" %}{% endif %}
         </div>
         <div
@@ -151,7 +151,7 @@ navigationKey: about
       >
         {{ skillset.description }}
       </h3>
-      <ul class="border-t bg-stone-100 p-2 pb-4">
+      <ul class="border-t bg-grey-100 p-2 pb-4">
         {% for skill in skillset.skills %}
           <li class="text-lg" style="font-variant-caps: all-small-caps">
             {{ skill }}

--- a/src/_includes/layouts/home.njk
+++ b/src/_includes/layouts/home.njk
@@ -40,7 +40,7 @@ navigationKey: about
 
 {{ subhead("about", "About Lyza") }}
 <main
-  class="prose col-span-12 lg:prose-lg sm:col-span-8 md:col-span-6 lg:col-span-7 lg:text-justify"
+  class="prose prose-stone col-span-12 lg:prose-lg sm:col-span-8 md:col-span-6 lg:col-span-7 lg:text-justify"
   id="skip"
 >
   {{ content | safe }}
@@ -87,7 +87,7 @@ navigationKey: about
           >
         </h3>
       </div>
-      <div class="prose prose-sm md:prose-base">
+      <div class="prose prose-sm prose-stone md:prose-base">
         {{ latestPost.data.excerpt }}
       </div>
       <div>

--- a/src/series.njk
+++ b/src/series.njk
@@ -21,7 +21,9 @@ navigationKey: posts
       </h1>
     </div>
     <div class="border-b pb-2">
-      <div class="prose prose-lg italic">{{ activeSeries.description }}</div>
+      <div class="prose prose-lg prose-stone italic">
+        {{ activeSeries.description }}
+      </div>
     </div>
   </div>
 </div>

--- a/styles/tailwind.config.js
+++ b/styles/tailwind.config.js
@@ -32,6 +32,7 @@ module.exports = {
       colors: {
         ...customColors,
         grey: colors.stone,
+        blue: colors.sky,
       },
       fontFamily: {
         body: ["'Georgia'", "'Times New Roman'", "serif"],

--- a/styles/tailwind.config.js
+++ b/styles/tailwind.config.js
@@ -58,6 +58,11 @@ module.exports = {
                 color: customColors.pank.DEFAULT,
               },
             },
+            // Remove literal quotation marks and backticks from blockquote, code
+            "blockquote p:first-of-type::before": { content: "none" },
+            "blockquote p:first-of-type::after": { content: "none" },
+            "code ::before": { content: "none" },
+            "code ::after": { content: "none" },
           },
         },
       },

--- a/styles/tailwind.css
+++ b/styles/tailwind.css
@@ -8,7 +8,7 @@
     * These anchors are added by the markdown-it-anchor plugin
     */
   .markdown-it-anchor-permalink {
-    @apply relative text-stone-800 no-underline hover:text-sky-800;
+    @apply relative text-grey-800 no-underline hover:text-sky-800;
 
     &::before {
       content: "#";

--- a/styles/tailwind.css
+++ b/styles/tailwind.css
@@ -8,7 +8,7 @@
     * These anchors are added by the markdown-it-anchor plugin
     */
   .markdown-it-anchor-permalink {
-    @apply relative text-grey-800 no-underline hover:text-sky-800;
+    @apply relative text-grey-800 no-underline hover:text-blue-800;
 
     &::before {
       content: "#";
@@ -16,7 +16,7 @@
     }
 
     &:hover::before {
-      @apply text-sky-800 md:absolute md:-ml-4 md:block;
+      @apply text-blue-800 md:absolute md:-ml-4 md:block;
     }
   }
 }


### PR DESCRIPTION
This PR tackles several tasks related to minor design and consolidation issues.

Fixes #31 - ensure that pages are at least `100vh` high (so that the footer on short-content pages isn't hanging out in the middle of the viewport

Fixes #26 - removes some slightly annoying default tailwindcss/typography plugin styles in `prose` content

Fixes #41 and Fixes #27 - Ensures light abstraction for tailwindcss colors (e.g. use "grey" instead of "stone" and "blue" instead of "sky") and vet color usage throughout

Fixes #20 (well sorta, indirectly) - Lay out tag lists in post summaries on a separate line in narrow viewports

Fixes #40 - link styling is consistent throughout