### PR TITLE
Refactor the series feature not to use `tags`

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,3 +14,11 @@ This project houses the source of [Lyza.com](https://www.lyza.com) built with th
 npm install
 npm start
 ```
+
+## Series Plugin
+
+An inelegant local 11ty plugin (`lib/series`) supports the ability to group content into "series". Series metadata is defined in `series.yaml`. To add a piece of content to a series, add an `inSeries` field to its front-matter, i.e. `inSeries: {seriesSlug}`[^1], referencing the `slug` of the `series` the content should be associated with. Series pages are output at `/series/{series.slug}` and navigation within a series is possible from within relevant content pages.
+
+The feature is designed this way to avoid coupling content source data with 11ty implementation details.
+
+[^1]: The field is keyed as `inSeries` to avoid namespace collision with `series` in 11ty's globals. This is an artifact of 11ty architecture.

--- a/lib/series.js
+++ b/lib/series.js
@@ -2,8 +2,16 @@ const yaml = require("js-yaml");
 const fs = require("fs");
 
 /**
+ * @typedef {Object} Series - Single series metadata entry in data `series.yaml`
+ * @prop {string} slug
+ * @prop {string} title
+ * @prop {string} description
+ */
+
+/**
  * Simple 11ty plugin to generate "series" collections from series YAML
- * metadata.
+ * metadata. Also adds a custom filter to look up a series in an array of
+ * series objects by slug.
  *
  * A collection is created for each entry in series data, keyed by `slug`.
  * Content can be added to a series (i.e. added to its collection) by adding an
@@ -14,21 +22,34 @@ const fs = require("fs");
  */
 module.exports = (eleventyConfig) => {
   const filepath = `./${eleventyConfig.dir.input}/${eleventyConfig.dir.data}/series.yaml`;
+
+  /** @type {Series[]} */
   const seriesData = yaml.load(fs.readFileSync(filepath, "utf8"));
 
-  // Look up a series global data object by slug
-  eleventyConfig.addFilter("getSeriesBySlug", (seriesData, slug) =>
-    seriesData.find((item) => item.slug == slug),
+  eleventyConfig.addFilter(
+    "getSeriesBySlug",
+    /**
+     * @param {Series[]} seriesData
+     * @param {string} slug
+     * @return {Series | undefined}
+     */
+
+    (seriesData, slug) => seriesData.find((item) => item.slug == slug),
   );
 
   // Add a collection for each series in data, keyed by its `slug` field
   // Add all content with front-matter/data `inSeries: {series-slug}` to the
   // collection
-  (seriesData || []).forEach((series) => {
-    eleventyConfig.addCollection(series.slug, function (collectionApi) {
-      return collectionApi
-        .getAllSorted()
-        .filter((item) => item.data?.inSeries === series.slug);
-    });
-  });
+  (seriesData || []).forEach(
+    /**
+     * @param {Series} series
+     */
+    (series) => {
+      eleventyConfig.addCollection(series.slug, function (collectionApi) {
+        return collectionApi
+          .getAllSorted()
+          .filter((item) => item.data?.inSeries === series.slug);
+      });
+    },
+  );
 };

--- a/lib/series.js
+++ b/lib/series.js
@@ -1,0 +1,34 @@
+const yaml = require("js-yaml");
+const fs = require("fs");
+
+/**
+ * Simple 11ty plugin to generate "series" collections from series YAML
+ * metadata.
+ *
+ * A collection is created for each entry in series data, keyed by `slug`.
+ * Content can be added to a series (i.e. added to its collection) by adding an
+ * `inSeries` field to front-matter. The value of the field should be the slug
+ * of the series to associate with.
+ *
+ * @param { import('@11ty/eleventy/src/UserConfig') }  eleventyConfig
+ */
+module.exports = (eleventyConfig) => {
+  const filepath = `./${eleventyConfig.dir.input}/${eleventyConfig.dir.data}/series.yaml`;
+  const seriesData = yaml.load(fs.readFileSync(filepath, "utf8"));
+
+  // Look up a series global data object by slug
+  eleventyConfig.addFilter("getSeriesBySlug", (seriesData, slug) =>
+    seriesData.find((item) => item.slug == slug),
+  );
+
+  // Add a collection for each series in data, keyed by its `slug` field
+  // Add all content with front-matter/data `inSeries: {series-slug}` to the
+  // collection
+  (seriesData || []).forEach((series) => {
+    eleventyConfig.addCollection(series.slug, function (collectionApi) {
+      return collectionApi
+        .getAllSorted()
+        .filter((item) => item.data?.inSeries === series.slug);
+    });
+  });
+};

--- a/src/_includes/components/series-navigation.njk
+++ b/src/_includes/components/series-navigation.njk
@@ -1,0 +1,27 @@
+<hr class="border-t border-grey-200 md:mx-4" />
+<div class="text-center md:text-xl">
+  <span class="font-display text-pank">Series</span> /
+  <span class="font-display"
+    ><a
+      class="transition-colors hover:text-pank hover:underline"
+      href="/series/{{ inSeries }}"
+      >{{ activeSeries.title }}</a
+    ></span
+  >
+</div>
+<div class="prose prose-stone flex max-w-none items-start gap-x-2 leading-none">
+  {% if prevPost %}
+    <div>«</div>
+    <div class="text-left leading-tight">
+      <div class="sr-only italic sm:not-sr-only">Previous in series:</div>
+      <a href="{{ prevPost.url }}">{{ prevPost.data.title }}</a>
+    </div>
+  {% endif %}
+  {% if nextPost %}
+    <div class="flex-grow text-right leading-tight">
+      <div class="sr-only italic sm:not-sr-only">Next in series:</div>
+      <a href="{{ nextPost.url }}">{{ nextPost.data.title }}</a>
+    </div>
+    <div>»</div>
+  {% endif %}
+</div>

--- a/src/_includes/components/series-toc.njk
+++ b/src/_includes/components/series-toc.njk
@@ -1,0 +1,35 @@
+<nav
+  class="mb-6 flex w-full flex-col
+sm:float-right sm:my-2 sm:ml-4 sm:w-1/2 sm:min-w-0"
+>
+  <div
+    class="border-b py-1 font-display text-lg sm:border-y sm:border-t-2 sm:p-1"
+  >
+    <span class="text-pank">Series</span> /
+    <a
+      class="not-prose transition-colors hover:text-pank hover:underline"
+      href="/series/{{ inSeries }}"
+      >{{ activeSeries.title }}</a
+    >
+  </div>
+  <p class="my-2 italic leading-snug md:text-sm">
+    {{ activeSeries.description }}
+  </p>
+
+  <div class="prose prose-stone">
+    <ol class="mt-0 border-b pb-1 leading-snug sm:text-sm">
+      {% for seriesPost in seriesPosts %}
+        <li>
+          <a
+            href="{{ seriesPost.url }}"
+            class="{% if seriesPost.url == page.url %}
+              text-grey-700 no-underline font-semibold
+            {% endif %} transition-colors hover:text-pank hover:underline"
+            {% if seriesPost.url == page.url %}aria-current="page"{% endif %}
+            >{{ seriesPost.data.title }}
+          </a>
+        </li>
+      {% endfor %}
+    </ol>
+  </div>
+</nav>

--- a/src/_includes/layouts/blog-post.njk
+++ b/src/_includes/layouts/blog-post.njk
@@ -13,7 +13,7 @@ navigationKey: posts
     <div class="border-b pb-2">
       <div class="prose prose-lg prose-stone italic">{{ excerpt }}</div>
     </div>
-    <ul class="font-smallcaps flex flex-row gap-2">
+    <ul class="flex flex-row gap-2 font-smallcaps">
       {% set postTags = tags | postTags %}
       {% for tag in postTags %}
         <li>
@@ -31,80 +31,17 @@ navigationKey: posts
  #  See https://stackoverflow.com/questions/55738093/prismjs-not-overflowing-with-css-grid
  #}
 <main class="col-span-12 min-w-0 overflow-auto md:col-span-8 md:pl-4" id="skip">
-  {% set seriesSlug = tags | seriesSlug %}
-  {% if seriesSlug %}
-    {% set seriesPosts = collections['series-' + seriesSlug] %}
-    {% set activeSeries = series | getSeriesBySlug(seriesSlug) %}
-    <nav
-      class="mb-6 flex w-full flex-col
-  sm:float-right sm:my-2 sm:ml-4 sm:w-1/2 sm:min-w-0"
-    >
-      <div
-        class="border-b py-1 font-display text-lg sm:border-y sm:border-t-2 sm:p-1"
-      >
-        <span class="text-pank">Series</span> /
-        <a
-          class="not-prose transition-colors hover:text-pank hover:underline"
-          href="/series/{{ seriesSlug }}"
-          >{{ activeSeries.title }}</a
-        >
-      </div>
-      <p class="my-2 italic leading-snug md:text-sm">
-        {{ activeSeries.description }}
-      </p>
-
-      <div class="prose prose-stone">
-        <ol class="mt-0 border-b pb-1 leading-snug sm:text-sm">
-          {% for seriesPost in seriesPosts %}
-            <li>
-              <a
-                href="{{ seriesPost.url }}"
-                class="{% if seriesPost.url == page.url %}
-                  text-grey-700 no-underline font-semibold
-                {% endif %} transition-colors hover:text-pank hover:underline"
-                {% if seriesPost.url == page.url %}aria-current="page"{% endif %}
-                >{{ seriesPost.data.title }}
-              </a>
-            </li>
-          {% endfor %}
-        </ol>
-      </div>
-    </nav>
+  {% if inSeries %}
+    {% set seriesPosts = collections[inSeries] %}
+    {% set activeSeries = series | getSeriesBySlug(inSeries) %}
+    {% include 'components/series-toc.njk' %}
   {% endif %}
   <div class="prose prose-stone">{{ content }}</div>
 </main>
 <div class="col-span-12 max-w-none space-y-4">
-  {% if seriesSlug %}
+  {% if inSeries %}
     {% set nextPost = seriesPosts | getNextCollectionItem(page) %}
     {% set prevPost = seriesPosts | getPreviousCollectionItem(page) %}
-    <hr class="border-t border-grey-200 md:mx-4" />
-    <div class="text-center md:text-xl">
-      <span class="font-display text-pank">Series</span> /
-      <span class="font-display"
-        ><a
-          class="transition-colors hover:text-pank hover:underline"
-          href="/series/{{ seriesSlug }}"
-          >{{ activeSeries.title }}</a
-        ></span
-      >
-    </div>
-    <div
-      class="prose prose-stone flex max-w-none items-start gap-x-2 leading-none"
-    >
-      {% if prevPost %}
-        <div>«</div>
-        <div class="text-left leading-tight">
-          <div class="sr-only italic sm:not-sr-only">Previous in series:</div>
-          <a href="{{ prevPost.url }}">{{ prevPost.data.title }}</a>
-        </div>
-      {% endif %}
-      {% if nextPost %}
-        <div class="flex-grow text-right leading-tight">
-          <div class="sr-only italic sm:not-sr-only">Next in series:</div>
-          <a href="{{ nextPost.url }}">{{ nextPost.data.title }}</a>
-        </div>
-        <div>»</div>
-      {% endif %}
-    </div>
+    {% include 'components/series-navigation.njk' %}
   {% endif %}
 </div>

--- a/src/series.njk
+++ b/src/series.njk
@@ -11,7 +11,7 @@ permalink: /series/{{ activeSeries.slug | slugify }}/
 navigationKey: posts
 ---
 
-{% set seriesItems = collections['series-' + activeSeries.slug] %}
+{% set seriesItems = collections[activeSeries.slug] %}
 
 <div class="col-span-12 space-y-4 md:col-span-4">
   <div class="static space-y-2 md:sticky md:top-0">


### PR DESCRIPTION
The way I implemented the series feature initially wasn't sitting well with me. This PR refactors the implementation without any user-facing changes (see #42 for what the feature behaves like).

#38 felt like a code smell (it is) — in general, using `tags` to associate content with series was likely to start an arms war. Any time I need to "filter out a given tag every time I render tags," that should give me pause. Also, it's infecting my source content's metadata with 11ty-coupled metaphors.

This updated implementation:

* Still uses `series.yaml` to define the series themselves
* Adds a basic 11ty "plugin" to create a collection for each entry in `series.yaml` (i.e. series generation/functionality is encapsulated in a plugin)
* Content can use an `inSeries`[^1] field in their front matter to associate with a series as desired. i.e. use `inSeries` instead of `tags`. This also obviates the need for code to ensure that a piece of content isn't in multiple series, as this field should take a single string value


[^1]: I document this in the project's README in these changes, but this field name bugs the heck out of me and is still an 11ty smell. I want to track separately seeing about namespacing data from global data files, because this is driving me nuts. If I use `series` for this field name — the intuitive name — it will conflict with global `series` data. Grr.

Fixes #38 by making it not a thing