### PR TITLE
Extract latest/featured content summary on home page

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,3 +22,14 @@ An inelegant local 11ty plugin (`lib/series`) supports the ability to group cont
 The feature is designed this way to avoid coupling content source data with 11ty implementation details.
 
 [^1]: The field is keyed as `inSeries` to avoid namespace collision with `series` in 11ty's globals. This is an artifact of 11ty architecture.
+
+## Featured content snippet on home page
+
+The featured-content ("The latest") snippet on the landing page (`index.md` content) will by default feature the most recent content tagged `'posts'` (i.e. the latest blog post). To feature something else, add a `featured` object to the front-matter/data of `index.md`, e.g.:
+
+```yaml
+featured:
+  title: Title of featured content
+  excerpt: Some description of featured content
+  url: /relative/to/site/root
+```

--- a/src/_includes/components/featured-summary.njk
+++ b/src/_includes/components/featured-summary.njk
@@ -1,0 +1,32 @@
+{% macro latest(title, excerpt, url, headline = "The latest") %}
+  <h2
+    class="font-display text-xl md:col-span-3 md:pr-8 md:text-right md:text-2xl lg:col-span-2"
+  >
+    {{ headline }}
+  </h2>
+  <div class="space-y-2 md:col-span-9 lg:col-span-10">
+    <div class="border-b">
+      <h3 class="font-display md:text-lg">
+        <a
+          href="{{ url }}"
+          class="transition-colors hover:text-pank hover:underline"
+          >{{ title }}</a
+        >
+      </h3>
+    </div>
+    <div class="prose prose-sm prose-stone md:prose-base">{{ excerpt }}</div>
+    <div>
+      <a
+        class="text-blue-800 underline transition-colors hover:text-pank"
+        href="{{ url }}"
+        >Read more...</a
+      >
+      |
+      <a
+        href="/blog"
+        class="text-blue-800 underline transition-colors hover:text-pank"
+        >All blog posts</a
+      >
+    </div>
+  </div>
+{% endmacro %}

--- a/src/_includes/layouts/home.njk
+++ b/src/_includes/layouts/home.njk
@@ -4,6 +4,8 @@ description: layout for the site landing page
 navigationKey: about
 ---
 
+{% from 'components/featured-summary.njk' import latest %}
+
 {% macro subhead(id, title) %}
   <div
     class="col-span-12 md:col-span-2 md:border-r md:pr-4 md:text-right lg:col-span-2"
@@ -69,44 +71,15 @@ navigationKey: about
   </ul>
 </div>
 
+{# look for `featured` in this content's front-matter else, feature the latest post #}
+{% set latestPost = collections.posts | last %}
+{% set featuredData = featured if featured else latestPost.data %}
+{% set featuredUrl = featured.url if featured else latestPost.url %}
+
 <div
   class="col-span-12 grid items-center gap-4 border-l border-l-8 border-pank bg-grey-100 p-3 md:grid-cols-12"
 >
-  <h2
-    class="font-display text-xl md:col-span-3 md:pr-8 md:text-right md:text-2xl lg:col-span-2"
-  >
-    The latest
-  </h2>
-  <div class="space-y-2 md:col-span-9 lg:col-span-10">
-    {% set latestPost = collections.posts | last %}
-    {% if latestPost %}
-      <div class="border-b">
-        <h3 class="font-display md:text-lg">
-          <a
-            href="{{ latestPost.url }}"
-            class="transition-colors hover:text-pank hover:underline"
-            >{{ latestPost.data.title }}</a
-          >
-        </h3>
-      </div>
-      <div class="prose prose-sm prose-stone md:prose-base">
-        {{ latestPost.data.excerpt }}
-      </div>
-      <div>
-        <a
-          class="text-blue-800 underline transition-colors hover:text-pank"
-          href="{{ latestPost.url }}"
-          >Read More</a
-        >
-        |
-        <a
-          href="/blog"
-          class="text-blue-800 underline transition-colors hover:text-pank"
-          >All blog posts</a
-        >
-      </div>
-    {% endif %}
-  </div>
+  {{ latest(featuredData.title, featuredData.excerpt, featuredUrl) }}
 </div>
 
 <div class="col-span-12">


### PR DESCRIPTION
Extract and make configurable the "latest" content blurb on the site's landing page. Featured content is by default the latest blog post but can be changed by adding a `featured` object to the front-matter/data for the landing page (`index.md`).

In future, this could be made more elegant, and almost assuredly more coherent with Nunjucks/11ty features.

No user-facing changes here.

Fixes #22