### PR TITLE
Add contact information to CV page

### DIFF
--- a/src/_data/profile.yaml
+++ b/src/_data/profile.yaml
@@ -1,17 +1,21 @@
 email: lyza@lyza.com
 identities:
-  - title: GitHub
+  github:
+    title: GitHub
     username: "@lyzadanger"
     url: https://github.com/lyzadanger
     icon: github
-  - title: Instagram
+  instagram:
+    title: Instagram
     username: "@lyzadanger"
     url: https://www.instagram.com/lyzadanger/
     icon: instagram
-  - title: Mastodon
+  mastodon:
+    title: Mastodon
     username: "@lyzadanger"
     url: https://indieweb.social/@lyzadanger
     icon: mastodon
-  - title: Email
+  email:
+    title: Email
     url: mailto:lyza@lyza.com
     icon: email

--- a/src/_includes/components/icon-link.njk
+++ b/src/_includes/components/icon-link.njk
@@ -1,0 +1,21 @@
+{% macro iconLink(url, title, icon) %}
+  <div
+    class="group font-light leading-none"
+    style="font-variant-caps:all-small-caps"
+  >
+    <a href="{{ url }}">
+      <div class="flex items-center gap-x-[0.4em] md:gap-x-[0.5em]">
+        <div
+          class="h-[0.8em] w-[0.8em] text-grey-700 transition-colors group-hover:text-pank"
+        >
+          {% if icon %}{% include "icons/" + icon + ".njk" %}{% endif %}
+        </div>
+        <div
+          class="-mt-[0.1em] text-pank transition-colors group-hover:underline"
+        >
+          {{ title }}
+        </div>
+      </div>
+    </a>
+  </div>
+{% endmacro %}

--- a/src/_includes/icons/email.njk
+++ b/src/_includes/icons/email.njk
@@ -13,7 +13,6 @@
   <g id="SVGRepo_iconCarrier">
     <path
       d="M4 7.00005L10.2 11.65C11.2667 12.45 12.7333 12.45 13.8 11.65L20 7"
-      stroke="#000000"
       stroke-width="2"
       stroke-linecap="round"
       stroke-linejoin="round"
@@ -24,7 +23,6 @@
       width="18"
       height="14"
       rx="2"
-      stroke="#000000"
       stroke-width="2"
       stroke-linecap="round"
     ></rect>

--- a/src/_includes/layouts/cv.njk
+++ b/src/_includes/layouts/cv.njk
@@ -4,6 +4,8 @@ layout: layouts/base.njk
 navigationKey: about
 ---
 
+{% from 'components/icon-link.njk' import iconLink %}
+
 {% macro experienceItem(experience) %}
   {% set eData = experience.data %}
   <div class="space-y-2">
@@ -51,47 +53,82 @@ navigationKey: about
     </div>
   </div>
 {% endmacro %}
-
 <div
-  class="order-last col-span-12 space-y-4 sm:order-first sm:col-span-4 print:space-y-3"
+  class="col-span-12 grid grid-cols-12 gap-4 sm:gap-y-6 md:gap-y-8 lg:gap-x-6"
 >
-  <h2 class="border-b font-display lg:text-lg">What I Can Do</h2>
-  <ul class="space-y-2 lg:space-y-4">
-    {% for skillset in skills %}
-      <li
-        class="rounded-lg bg-grey-100 p-2 lg:p-3 print:bg-transparent print:p-0"
-      >
-        <h3
-          class="border-b border-grey-500 pb-1 text-sm font-semibold italic leading-tight text-pank lg:text-base lg:leading-snug print:border-none print:leading-none"
-        >
-          {{ skillset.description }}
-        </h3>
-        <ul class="font-smallcaps list-inside list-disc p-2 text-sm">
-          {% for skill in skillset.skills %}
-            <li class="marker:text-pank-300 print:leading-none">{{ skill }}</li>
-          {% endfor %}
-        </ul>
-      </li>
-    {% endfor %}
-  </ul>
-</div>
-<div class="col-span-12 max-w-none space-y-3 sm:col-span-8 md:space-y-4">
+  <div class="col-span-12 max-w-none space-y-3 sm:col-span-8 md:space-y-4">
+    <div
+      class="prose prose-sm prose-stone max-w-none leading-snug md:prose-lg md:text-justify md:leading-normal"
+    >
+      {{ content | safe }}
+    </div>
+  </div>
   <div
-    class="prose prose-sm prose-stone leading-snug md:prose-lg md:text-justify md:leading-normal"
+    class="order-first col-span-12 space-y-4 sm:order-none sm:col-span-4 print:space-y-3"
   >
-    {{ content | safe }}
+    <div class="text-center">
+      <h2 class="font-display text-lg sm:text-base md:text-lg lg:text-xl">
+        Lyza Danger Gardner
+      </h2>
+      <h3 class="font-display text-sm italic lg:text-base">
+        Senior Developer / Web Advocate
+      </h3>
+    </div>
+    <div class="flex flex-col items-center">
+      {% set email = profile.identities.email %}
+      {% set mastodon = profile.identities.mastodon %}
+      {% set github = profile.identities.github %}
+      <div class="text-center text-xl sm:text-2xl">
+        {{ iconLink(email.url, 'lyza@lyza.com', email.icon) }}
+      </div>
+      <div
+        class="hidden font-display text-base italic leading-tight sm:text-lg print:block"
+      >
+        www.lyza.com
+      </div>
+      <div class="flex items-center gap-x-2 text-base sm:text-lg print:hidden">
+        {{ iconLink(mastodon.url, mastodon.title, mastodon.icon) }}
+        <div>|</div>
+        {{ iconLink(github.url, github.title, github.icon) }}
+      </div>
+    </div>
   </div>
 
-  <h2 class="border-b-2 font-display text-lg md:text-2xl">Experience</h2>
-  <ul class="space-y-4">
-    {% for exp in collections.experience | reverse %}
-      <li>{{ experienceItem(exp) }}</li>
-    {% endfor %}
-  </ul>
-  <h2 class="border-b-2 font-display text-xl">Education</h2>
-  <ul class="space-y-4">
-    {% for edu in education | reverse %}
-      <li>{{ educationItem(edu) }}</li>
-    {% endfor %}
-  </ul>
+  <div class="col-span-12 space-y-4 sm:col-span-4 print:space-y-3">
+    <h2 class="border-b-2 font-display text-lg md:text-2xl">What I Can Do</h2>
+    <ul class="space-y-2 lg:space-y-4">
+      {% for skillset in skills %}
+        <li
+          class="rounded-lg bg-grey-100 p-2 lg:p-3 print:bg-transparent print:p-0"
+        >
+          <h3
+            class="border-b border-grey-500 pb-1 text-sm font-semibold italic leading-tight text-pank lg:text-base lg:leading-snug print:border-none print:leading-none"
+          >
+            {{ skillset.description }}
+          </h3>
+          <ul class="list-inside list-disc p-2 font-smallcaps text-sm">
+            {% for skill in skillset.skills %}
+              <li class="marker:text-pank-300 print:leading-none">
+                {{ skill }}
+              </li>
+            {% endfor %}
+          </ul>
+        </li>
+      {% endfor %}
+    </ul>
+  </div>
+  <div class="col-span-12 max-w-none space-y-3 sm:col-span-8 md:space-y-4">
+    <h2 class="border-b-2 font-display text-lg md:text-2xl">Experience</h2>
+    <ul class="space-y-4">
+      {% for exp in collections.experience | reverse %}
+        <li>{{ experienceItem(exp) }}</li>
+      {% endfor %}
+    </ul>
+    <h2 class="border-b-2 font-display text-xl">Education</h2>
+    <ul class="space-y-4">
+      {% for edu in education | reverse %}
+        <li>{{ educationItem(edu) }}</li>
+      {% endfor %}
+    </ul>
+  </div>
 </div>

--- a/src/_includes/layouts/cv.njk
+++ b/src/_includes/layouts/cv.njk
@@ -94,7 +94,9 @@ navigationKey: about
     </div>
   </div>
 
-  <div class="col-span-12 space-y-4 sm:col-span-4 print:space-y-3">
+  <div
+    class="order-last col-span-12 space-y-4 sm:col-span-4 md:order-none print:space-y-3"
+  >
     <h2 class="border-b-2 font-display text-lg md:text-2xl">What I Can Do</h2>
     <ul class="space-y-2 lg:space-y-4">
       {% for skillset in skills %}

--- a/src/_includes/layouts/cv.njk
+++ b/src/_includes/layouts/cv.njk
@@ -95,7 +95,7 @@ navigationKey: about
   </div>
 
   <div
-    class="order-last col-span-12 space-y-4 sm:col-span-4 md:order-none print:space-y-3"
+    class="order-last col-span-12 space-y-4 sm:order-none sm:col-span-4 print:space-y-3"
   >
     <h2 class="border-b-2 font-display text-lg md:text-2xl">What I Can Do</h2>
     <ul class="space-y-2 lg:space-y-4">

--- a/src/_includes/layouts/home.njk
+++ b/src/_includes/layouts/home.njk
@@ -5,6 +5,7 @@ navigationKey: about
 ---
 
 {% from 'components/featured-summary.njk' import latest %}
+{% from 'components/icon-link.njk' import iconLink %}
 
 {% macro subhead(id, title) %}
   <div
@@ -18,28 +19,6 @@ navigationKey: about
       </h2>
     </a>
   </div>
-{% endmacro %}
-
-{% macro iconLink(url, title, icon) %}
-  <li
-    class="group text-xl font-light leading-none"
-    style="font-variant-caps:all-small-caps"
-  >
-    <a href="{{ url }}">
-      <div class="flex items-center gap-x-2 md:gap-x-3">
-        <div
-          class="h-4 w-4 text-grey-700 transition-colors group-hover:text-pank"
-        >
-          {% if icon %}{% include "icons/" + icon + ".njk" %}{% endif %}
-        </div>
-        <div
-          class="-mt-[2px] text-pank transition-colors group-hover:underline"
-        >
-          {{ title }}
-        </div>
-      </div>
-    </a>
-  </li>
 {% endmacro %}
 
 {{ subhead("about", "About Lyza") }}
@@ -56,15 +35,15 @@ navigationKey: about
   <h2 class="border-b pb-2 font-display text-lg sm:text-base lg:text-lg">
     Find me out there
   </h2>
-  <ul class="space-y-4 px-2 md:space-y-3 md:p-4">
-    {% for identity in profile.identities %}
-      {{ iconLink(identity.url, identity.title, identity.icon) }}
+  <ul class="space-y-4 px-2 text-xl md:space-y-3 md:p-4">
+    {% for key, identity in profile.identities %}
+      <li>{{ iconLink(identity.url, identity.title, identity.icon) }}</li>
     {% endfor %}
   </ul>
   <h2 class="border-b pb-2 font-display text-lg sm:text-base lg:text-lg">
     Follow my work (and play)
   </h2>
-  <ul class="space-y-4 px-2 md:space-y-3 md:p-4">
+  <ul class="space-y-4 px-2 text-xl md:space-y-3 md:p-4">
     {{ iconLink("/feeds/rss.rss", "RSS: Everything", "rss") }}
     {{ iconLink("/feeds/tech.rss", "RSS: Tech stuff", "rss") }}
     {{ iconLink("/feeds/life.rss", "RSS: Non-tech stuff", "rss") }}


### PR DESCRIPTION
This PR adds some personal and contact info to the top of the CV page. As part of that, it also extracts an `icon-link` Nunjucks macro and refactors it a little for reuse. 

Print styles suppress the GitHub/Mastodon links (as they are not useful in a printed representation) and subs in `'www.lyza.com'`.

As of these changes, the CV pages looks like this on wide screens:

<img src="https://github.com/lyzadanger/lyza-dot-11ty/assets/439947/7e02b6e9-19ef-4383-9661-2ffc6971b9e7" width="500" />

like so on narrow screens:

<img src="https://github.com/lyzadanger/lyza-dot-11ty/assets/439947/51df4870-0418-4da5-88a0-310eb297fa42" width="350" />

Fixes #14