### PR TITLE
Support markdown in blog post excerpts

### DIFF
--- a/src/_includes/components/featured-summary.njk
+++ b/src/_includes/components/featured-summary.njk
@@ -14,7 +14,9 @@
         >
       </h3>
     </div>
-    <div class="prose prose-sm prose-stone md:prose-base">{{ excerpt }}</div>
+    <div class="prose prose-sm prose-stone md:prose-base">
+      {% markdown %}{{ excerpt }}{% endmarkdown %}
+    </div>
     <div>
       <a
         class="text-blue-800 underline transition-colors hover:text-pank"

--- a/src/_includes/components/post-summary.njk
+++ b/src/_includes/components/post-summary.njk
@@ -16,7 +16,7 @@
         {{ post.date | localeDate }}
       </h4>
       <div class="sm:flex-grow">
-        <ul class="font-smallcaps flex flex-row gap-2 sm:justify-end">
+        <ul class="flex flex-row gap-2 font-smallcaps sm:justify-end">
           {% for tag in post.data.tags | postTags %}
             <li class="font-smallcaps text-sm text-grey-600">
               <a
@@ -32,6 +32,6 @@
   </div>
 
   <div class="font-body text-grey-700">
-    {% if post.data.excerpt %}{{ post.data.excerpt }}{% endif %}
+    {% if post.data.excerpt %}{% markdown %}{{ post.data.excerpt }}{% endmarkdown %}{% endif %}
   </div>
 </div>

--- a/src/_includes/layouts/blog-post.njk
+++ b/src/_includes/layouts/blog-post.njk
@@ -11,7 +11,9 @@ navigationKey: posts
       <h4 class="italic">{{ page.date | localeDate }}</h4>
     </div>
     <div class="border-b pb-2">
-      <div class="prose prose-lg prose-stone italic">{{ excerpt }}</div>
+      <div class="prose prose-lg prose-stone italic">
+        {% markdown %}{{ excerpt }}{% endmarkdown %}
+      </div>
     </div>
     <ul class="flex flex-row gap-2 font-smallcaps">
       {% set postTags = tags | postTags %}


### PR DESCRIPTION
Use recently-added `markdown` shortcode for this. NB: `og:description` content is still plaintext.

Fixes #25