### PR TITLE
Add additional RSS redirect

### DIFF
--- a/src/public/_redirects
+++ b/src/public/_redirects
@@ -10,3 +10,4 @@
 # Currently the landing page of the site serves as about
 /about   			/
 /about/bio			/
+/feed         /feeds/rss.rss


### PR DESCRIPTION
Apparently some old variant of my RSS feed was being served at /feed, so support that.

Ideally this would be a real and permanent URL instead of a redirect. In future, I might flip this redirect/actually have a `/feed` resource.