### PR TITLE
Make a few small improvements to the Series feature

### DIFF
--- a/src/_includes/components/post-summary.njk
+++ b/src/_includes/components/post-summary.njk
@@ -7,7 +7,7 @@
       class="transition-colors hover:text-pank hover:underline"
     >
       {% if post.data.title %}
-        <h3 class="font-display text-xl">{{ post.data.title }}</h3>
+        <h3 class="text-pretty font-display text-xl">{{ post.data.title }}</h3>
       {% endif %}
     </a>
 

--- a/src/_includes/layouts/blog-post.njk
+++ b/src/_includes/layouts/blog-post.njk
@@ -17,7 +17,7 @@ navigationKey: posts
     <div
       class="{% if inSeries %}border-grey-300{% endif %} border-b py-2 font-display"
     >
-      <h2 class="text-xl">{{ title }}</h2>
+      <h2 class="text-pretty text-xl">{{ title }}</h2>
       <h4 class="italic">{{ page.date | localeDate }}</h4>
     </div>
     {% if not inSeries %}

--- a/src/_includes/layouts/blog-post.njk
+++ b/src/_includes/layouts/blog-post.njk
@@ -54,6 +54,6 @@ navigationKey: posts
 </main>
 <div class="col-span-12 max-w-none space-y-4">
   {% if inSeries %}
-    {{ seriesNavigation(activeSeries, nextPost, prevPost) }}
+    {{ seriesNavigation(activeSeries, prevPost, nextPost) }}
   {% endif %}
 </div>

--- a/src/_includes/series.njk
+++ b/src/_includes/series.njk
@@ -45,7 +45,7 @@
     <p class="my-2 italic leading-snug md:text-sm">{{ series.description }}</p>
 
     <nav class="prose prose-stone">
-      <ol class="mt-0 leading-snug sm:text-sm">
+      <ol class="mt-0 text-pretty leading-snug sm:text-sm">
         {% for seriesPost in seriesPosts %}
           <li>
             <a

--- a/src/series.njk
+++ b/src/series.njk
@@ -22,7 +22,7 @@ navigationKey: posts
     </div>
     <div class="border-b pb-2">
       <div class="prose prose-lg prose-stone italic">
-        {{ activeSeries.description }}
+        {% markdown %}{{ activeSeries.description }}{% endmarkdown %}
       </div>
     </div>
   </div>


### PR DESCRIPTION
This PR tackles a few details on the Series feature (_still_ no series content so no user-visible changes, yet).

* Fix swapped next/previous links in blog-post footer (whoops)
* Wrap blog titles more nicely with `text-wrap: pretty` in a few spots
* Support markdown in series descriptions