### PR TITLE
Auto-generate Open Graph images using Cloudinary API

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -11,6 +11,8 @@ const syntaxHighlight = require("@11ty/eleventy-plugin-syntaxhighlight");
 
 const seriesPlugin = require("./lib/series");
 
+const siteConfig = require("./src/_data/config");
+
 module.exports = function (eleventyConfig) {
   // 11ty plugins
   eleventyConfig.addPlugin(EleventyHtmlBasePlugin);
@@ -118,6 +120,32 @@ module.exports = function (eleventyConfig) {
       return 0;
     });
     return tags;
+  });
+
+  // Take a title and return a URL to a composited Open Graph image via
+  // Cloudinary's image-transform URL API
+  eleventyConfig.addFilter("cloudinaryOGImage", (title) => {
+    if (!siteConfig.cloudinary?.id) {
+      return undefined;
+    }
+
+    const cloudinaryURLParts = [
+      // Set up fetch URI, with cloudinary ID and size of overall image (the URL to the image
+      // used here comes at the very end of the URL). Set height, width, quality
+      `https://res.cloudinary.com/${siteConfig.cloudinary.id}/image/fetch/w_1200,h_630,q_100`,
+      // Static: Render "Lyza / Danger / Gardner" text layers
+      "co_rgb:000,l_text:Playfair%20Display_72_900_line:Lyza,c_fit,w_540/fl_layer_apply,g_north_west,x_40,y_40/co_rgb:000,l_text:Playfair%20Display_72_900_line:Gardner,c_fit,w_540/fl_layer_apply,g_north_west,x_40,y_135/co_rgb:e60a62,l_text:Playfair%20Display_72_900_line:Danger,c_fit,w_540/fl_layer_apply,g_north_west,x_60,y_92",
+      // Static: Render a photo of me in bottom right. This contains Base-64 encoded URL to image of me on cloudinary
+      "l_fetch:aHR0cHM6Ly9yZXMuY2xvdWRpbmFyeS5jb20vZGZzc3Nkd2J1L2ltYWdlL3VwbG9hZC92MTcwOTIyNjEyOC9seXphX2loNnJray5naWY=/fl_layer_apply,g_south_east",
+      // Static: Render "Lyza.com" on bottom right, near photo of me
+      "co_rgb:e60a62,l_text:Playfair%20Display%20SC_36_bold_line_spacing_-20:Lyza.Com,c_fit,w_500/fl_layer_apply,g_south_east,x_220,y_20",
+      // Render the title of the post/thing
+      // NB: ',', '/' and '%' must be double-escaped. Failure mode otherwise is not graceful
+      `co_rgb:44403c,l_text:Playfair%20Display_72_400_italic_line_spacing_-15:${encodeURIComponent(title.replaceAll(/[,\/\%]/g, encodeURIComponent))},c_fit,w_800/fl_layer_apply,g_north,y_240`,
+      // And, finally, give the URL of the image that will be at the base/background of all of this
+      "https://res.cloudinary.com/dfsssdwbu/image/upload/v1709226095/white_ldpjpk.jpg",
+    ];
+    return cloudinaryURLParts.join("/");
   });
 
   // Config directories

--- a/.eleventy.js
+++ b/.eleventy.js
@@ -10,6 +10,7 @@ const pluginRss = require("@11ty/eleventy-plugin-rss");
 const syntaxHighlight = require("@11ty/eleventy-plugin-syntaxhighlight");
 
 const seriesPlugin = require("./lib/series");
+const cloudinaryPlugin = require("./lib/cloudinary");
 
 const siteConfig = require("./src/_data/config");
 
@@ -21,6 +22,7 @@ module.exports = function (eleventyConfig) {
 
   // My own plugins
   eleventyConfig.addPlugin(seriesPlugin);
+  eleventyConfig.addPlugin(cloudinaryPlugin, siteConfig?.cloudinary);
 
   // Extend markdown transformation with permalinks and footnotes support
   eleventyConfig.amendLibrary("md", (mdLib) => mdLib.use(markdownItFootnote));
@@ -120,62 +122,6 @@ module.exports = function (eleventyConfig) {
       return 0;
     });
     return tags;
-  });
-
-  // Take a title and return a URL to a composited Open Graph image via
-  // Cloudinary's image-transform URL API
-  eleventyConfig.addFilter("cloudinaryOGImage", (title, imageUrl) => {
-    if (!siteConfig.cloudinary?.id) {
-      return undefined;
-    }
-
-    // NB: ',', '/' and '%' must be double-escaped to render on a text layer
-    // on Cloudinary. Failure mode ugly.
-    const encodedTitle = encodeURIComponent(
-      title.replaceAll(/[,\/\%]/g, encodeURIComponent),
-    );
-    // Size and position of title text depends on whether there's a content-
-    // specific image (imageUrl provided) or not.
-    // With image: text takes of left size of image, and is smaller to make
-    // room for image.
-    // No image: text is fuller-width and larger
-    const titleSize = imageUrl ? "60" : "72";
-    const titleLayerOptions = imageUrl
-      ? "c_fit,w_540/fl_layer_apply,g_west,x_40"
-      : "c_fit,w_800/fl_layer_apply,g_north,y_240";
-
-    const cloudinaryUrlParts = [
-      // Set up fetch URI, with cloudinary ID and size of overall image (the URL to the image
-      // used here comes at the very end of the URL). Set height, width, quality
-      `https://res.cloudinary.com/${siteConfig.cloudinary.id}/image/fetch/w_1200,h_630,q_100`,
-      // Static: Render "Lyza / Danger / Gardner" text layers
-      "co_rgb:000,l_text:Playfair%20Display_72_900_line:Lyza,c_fit,w_540/fl_layer_apply,g_north_west,x_40,y_40/co_rgb:000,l_text:Playfair%20Display_72_900_line:Gardner,c_fit,w_540/fl_layer_apply,g_north_west,x_40,y_135/co_rgb:e60a62,l_text:Playfair%20Display_72_900_line:Danger,c_fit,w_540/fl_layer_apply,g_north_west,x_60,y_92",
-    ];
-
-    // If the content has an image to be used, make it half the width of the
-    // OG image (taking margins into account), aligned on the right.
-    if (imageUrl) {
-      const encodedURL = Buffer.from(imageUrl, "utf8").toString("base64");
-      cloudinaryUrlParts.push(
-        `l_fetch:${encodedURL}/fl_layer_apply,c_fit,h_520,w_540,g_east,x_40`,
-      );
-    }
-
-    cloudinaryUrlParts.push(
-      // Static: Render a photo of me in bottom right. This contains Base-64 encoded URL to image of me on cloudinary
-      "l_fetch:aHR0cHM6Ly9yZXMuY2xvdWRpbmFyeS5jb20vZGZzc3Nkd2J1L2ltYWdlL3VwbG9hZC92MTcwOTIyNjEyOC9seXphX2loNnJray5naWY=/fl_layer_apply,g_south_east",
-      // Static: Render "Lyza.com" on bottom right, near photo of me
-      "co_rgb:e60a62,l_text:Playfair%20Display%20SC_36_bold_line_spacing_-20:Lyza.Com,c_fit,w_500/fl_layer_apply,g_south_east,x_220,y_20",
-      // Render the title of the post/thing
-      `co_rgb:44403c,l_text:Playfair%20Display_${titleSize}_400_italic_line_spacing_-15:${encodedTitle},${titleLayerOptions}`,
-    );
-
-    // And, finally, give the URL of the image that will be at the base/background of all of this
-    cloudinaryUrlParts.push(
-      "https://res.cloudinary.com/dfsssdwbu/image/upload/v1709226095/white_ldpjpk.jpg",
-    );
-
-    return cloudinaryUrlParts.join("/");
   });
 
   // Config directories

--- a/lib/cloudinary.js
+++ b/lib/cloudinary.js
@@ -45,7 +45,7 @@ module.exports = (eleventyConfig, config = {}) => {
       // - no post image: text positioned centered under LDG type treatment,
       //     spanning most of the width of the OG image
       const titleLayerOptions = imageUrl
-        ? "c_fit,w_540/fl_layer_apply,g_west,x_40"
+        ? "c_fit,w_540/fl_layer_apply,g_west,x_50"
         : "c_fit,w_800/fl_layer_apply,g_north,y_240";
 
       const cloudinaryUrlParts = [
@@ -54,9 +54,9 @@ module.exports = (eleventyConfig, config = {}) => {
         `https://res.cloudinary.com/${config.id}/image/fetch/w_1200,h_630,q_100`,
         // Static: Render "Lyza / Danger / Gardner" text layers at top left
         // Danger comes last because it's composited on top of the other two
-        "co_rgb:000,l_text:Playfair%20Display_72_900_line:Lyza,c_fit,w_540/fl_layer_apply,g_north_west,x_40,y_40",
-        "co_rgb:000,l_text:Playfair%20Display_72_900_line:Gardner,c_fit,w_540/fl_layer_apply,g_north_west,x_40,y_135",
-        "co_rgb:e60a62,l_text:Playfair%20Display_72_900_line:Danger,c_fit,w_540/fl_layer_apply,g_north_west,x_60,y_92",
+        "co_rgb:000,l_text:Playfair%20Display_72_900_line:Lyza,c_fit,w_540/fl_layer_apply,g_north_west,x_50,y_40",
+        "co_rgb:000,l_text:Playfair%20Display_72_900_line:Gardner,c_fit,w_540/fl_layer_apply,g_north_west,x_50,y_135",
+        "co_rgb:e60a62,l_text:Playfair%20Display_72_900_line:Danger,c_fit,w_540/fl_layer_apply,g_north_west,x_70,y_92",
       ];
 
       // If the content has an image to be used, make it half the width of the
@@ -65,7 +65,7 @@ module.exports = (eleventyConfig, config = {}) => {
       if (imageUrl) {
         const encodedURL = Buffer.from(imageUrl, "utf8").toString("base64");
         cloudinaryUrlParts.push(
-          `l_fetch:${encodedURL}/fl_layer_apply,c_fit,h_510,w_540,g_east,x_40`,
+          `l_fetch:${encodedURL}/fl_layer_apply,c_fit,h_510,w_540,g_east,x_50`,
         );
       }
 

--- a/lib/cloudinary.js
+++ b/lib/cloudinary.js
@@ -51,7 +51,7 @@ module.exports = (eleventyConfig, config = {}) => {
       const cloudinaryUrlParts = [
         // Establish the bounds of the image canvas and denote that the end of
         // the URL will be a URL to "fetch" the backgorund image from
-        `https://res.cloudinary.com/${config.id}/image/fetch/w_1200,h_630,q_100`,
+        `https://res.cloudinary.com/${config.id}/image/fetch/w_1200,h_600,q_100`,
         // Static: Render "Lyza / Danger / Gardner" text layers at top left
         // Danger comes last because it's composited on top of the other two
         "co_rgb:000,l_text:Playfair%20Display_72_900_line:Lyza,c_fit,w_540/fl_layer_apply,g_north_west,x_40,y_40",
@@ -65,7 +65,7 @@ module.exports = (eleventyConfig, config = {}) => {
       if (imageUrl) {
         const encodedURL = Buffer.from(imageUrl, "utf8").toString("base64");
         cloudinaryUrlParts.push(
-          `l_fetch:${encodedURL}/fl_layer_apply,c_fit,h_510,w_540,g_east,x_40`,
+          `l_fetch:${encodedURL}/fl_layer_apply,c_fit,h_500,w_540,g_east,x_40`,
         );
       }
 

--- a/lib/cloudinary.js
+++ b/lib/cloudinary.js
@@ -51,7 +51,7 @@ module.exports = (eleventyConfig, config = {}) => {
       const cloudinaryUrlParts = [
         // Establish the bounds of the image canvas and denote that the end of
         // the URL will be a URL to "fetch" the backgorund image from
-        `https://res.cloudinary.com/${config.id}/image/fetch/w_1200,h_600,q_100`,
+        `https://res.cloudinary.com/${config.id}/image/fetch/w_1200,h_630,q_100`,
         // Static: Render "Lyza / Danger / Gardner" text layers at top left
         // Danger comes last because it's composited on top of the other two
         "co_rgb:000,l_text:Playfair%20Display_72_900_line:Lyza,c_fit,w_540/fl_layer_apply,g_north_west,x_40,y_40",
@@ -65,7 +65,7 @@ module.exports = (eleventyConfig, config = {}) => {
       if (imageUrl) {
         const encodedURL = Buffer.from(imageUrl, "utf8").toString("base64");
         cloudinaryUrlParts.push(
-          `l_fetch:${encodedURL}/fl_layer_apply,c_fit,h_500,w_540,g_east,x_40`,
+          `l_fetch:${encodedURL}/fl_layer_apply,c_fit,h_510,w_540,g_east,x_40`,
         );
       }
 

--- a/lib/cloudinary.js
+++ b/lib/cloudinary.js
@@ -1,0 +1,93 @@
+/**
+ * @typedef CloudinaryConfig
+ * @prop {string} id - User ID for cloudinary
+ */
+
+const fallbackImageUrl =
+  "https://res.cloudinary.com/dfsssdwbu/image/fetch/v1709240637/https://www.lyza.com/images/lyza.gif";
+
+/**
+ * 11ty plugin that adds a filter to generate an Open Graph image from the
+ * title of the post/page and optionally including a specific image for
+ * that post. This works by constructing a monster URL using Cloudinary's
+ * Transformation URL API.
+ *
+ * https://cloudinary.com/documentation/transformation_reference
+ *
+ * @param { import('@11ty/eleventy/src/UserConfig') }  eleventyConfig
+ * @param {CloudinaryConfig} [config]
+ */
+module.exports = (eleventyConfig, config = {}) => {
+  if (!config || !config.id) {
+    return fallbackImageUrl;
+  }
+
+  // Return URL to composited Open Graph image
+  eleventyConfig.addShortcode(
+    "cloudinaryOGImage",
+    /**
+     * @param {string} title - Title of post or content page
+     * @param {string} [imageUrl] - URL to a post- or content-specific image
+     *                 It will be resized and positioned in the OG image
+     */
+    (title, imageUrl) => {
+      // A number of characters must be double-escaped to render on a text
+      // layer on Cloudinary. Prepare the title, else failure mode ugly.
+      // https://support.cloudinary.com/hc/en-us/articles/202521512-How-to-add-a-special-characters-in-text-overlays
+      const encodedTitle = encodeURIComponent(
+        title.replaceAll(/[\?#,\/\%]/g, encodeURIComponent),
+      );
+
+      // Make font larger if there is no post-specific image
+      const titleSize = imageUrl ? "60" : "72";
+      // - with post image: text positioned left under LDG type treatment,
+      //     spanning half width of OG image
+      // - no post image: text positioned centered under LDG type treatment,
+      //     spanning most of the width of the OG image
+      const titleLayerOptions = imageUrl
+        ? "c_fit,w_540/fl_layer_apply,g_west,x_40"
+        : "c_fit,w_800/fl_layer_apply,g_north,y_240";
+
+      const cloudinaryUrlParts = [
+        // Establish the bounds of the image canvas and denote that the end of
+        // the URL will be a URL to "fetch" the backgorund image from
+        `https://res.cloudinary.com/${config.id}/image/fetch/w_1200,h_630,q_100`,
+        // Static: Render "Lyza / Danger / Gardner" text layers at top left
+        // Danger comes last because it's composited on top of the other two
+        "co_rgb:000,l_text:Playfair%20Display_72_900_line:Lyza,c_fit,w_540/fl_layer_apply,g_north_west,x_40,y_40",
+        "co_rgb:000,l_text:Playfair%20Display_72_900_line:Gardner,c_fit,w_540/fl_layer_apply,g_north_west,x_40,y_135",
+        "co_rgb:e60a62,l_text:Playfair%20Display_72_900_line:Danger,c_fit,w_540/fl_layer_apply,g_north_west,x_60,y_92",
+      ];
+
+      // If the content has an image to be used, make it half the width of the
+      // OG image (taking margins into account), aligned on the right. This needs
+      // to be composited behind some of the following layers.
+      if (imageUrl) {
+        const encodedURL = Buffer.from(imageUrl, "utf8").toString("base64");
+        cloudinaryUrlParts.push(
+          `l_fetch:${encodedURL}/fl_layer_apply,c_fit,h_510,w_540,g_east,x_40`,
+        );
+      }
+
+      cloudinaryUrlParts.push(
+        // Static: Render a photo of me in bottom right. This contains Base-64
+        // encoded URL to image of me on cloudinary. This image may partially
+        // obscure the post image (by design).
+        "l_fetch:aHR0cHM6Ly9yZXMuY2xvdWRpbmFyeS5jb20vZGZzc3Nkd2J1L2ltYWdlL3VwbG9hZC92MTcwOTIyNjEyOC9seXphX2loNnJray5naWY=/fl_layer_apply,g_south_east",
+        // Static: Render "Lyza.com" on bottom right, near photo of me
+        "co_rgb:e60a62,l_text:Playfair%20Display%20SC_36_bold_line_spacing_-20:Lyza.Com,c_fit,w_500/fl_layer_apply,g_south_east,x_220,y_20",
+        // Render the title of the post/content. Last to ensure it's composited
+        // on top
+        `co_rgb:44403c,l_text:Playfair%20Display_${titleSize}_400_italic_line_spacing_-15:${encodedTitle},${titleLayerOptions}`,
+      );
+
+      // And, finally, give the URL of the image that will be at the
+      // background of all of this, which is just a white rectangle
+      cloudinaryUrlParts.push(
+        "https://res.cloudinary.com/dfsssdwbu/image/upload/v1709226095/white_ldpjpk.jpg",
+      );
+
+      return cloudinaryUrlParts.join("/");
+    },
+  );
+};

--- a/src/_data/config.js
+++ b/src/_data/config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  cloudinary: { id: "dfsssdwbu" },
+};

--- a/src/_includes/layouts/base.njk
+++ b/src/_includes/layouts/base.njk
@@ -18,13 +18,12 @@
       property="og:url"
       content="{{ page.url | htmlBaseUrl(metadata.url) }}"
     />
-    {% set ogImage = '/images/lyza.gif' | htmlBaseUrl(metadata.url) %}
     {% if og and og.image %}
       {% set ogImage = og.image %}
     {% endif %}
     <meta
       property="og:image"
-      content="{{ title | cloudinaryOGImage(ogImage) | default(defaultOgImage) }}"
+      content="{% cloudinaryOGImage title, ogImage %}"
     />
     {% if excerpt %}
       <meta property="og:description" content="{{ excerpt }}" />

--- a/src/_includes/layouts/base.njk
+++ b/src/_includes/layouts/base.njk
@@ -18,10 +18,13 @@
       property="og:url"
       content="{{ page.url | htmlBaseUrl(metadata.url) }}"
     />
-    {% set defaultOgImage = '/images/lyza.gif' | htmlBaseUrl(metadata.url) %}
+    {% set ogImage = '/images/lyza.gif' | htmlBaseUrl(metadata.url) %}
+    {% if og and og.image %}
+      {% set ogImage = og.image %}
+    {% endif %}
     <meta
       property="og:image"
-      content="{{ title | cloudinaryOGImage | default(defaultOgImage) }}"
+      content="{{ title | cloudinaryOGImage(ogImage) | default(defaultOgImage) }}"
     />
     {% if excerpt %}
       <meta property="og:description" content="{{ excerpt }}" />

--- a/src/_includes/layouts/base.njk
+++ b/src/_includes/layouts/base.njk
@@ -18,9 +18,10 @@
       property="og:url"
       content="{{ page.url | htmlBaseUrl(metadata.url) }}"
     />
+    {% set defaultOgImage = '/images/lyza.gif' | htmlBaseUrl(metadata.url) %}
     <meta
       property="og:image"
-      content="{{ '/images/lyza.gif' | htmlBaseUrl(metadata.url) }}"
+      content="{{ title | cloudinaryOGImage | default(defaultOgImage) }}"
     />
     {% if excerpt %}
       <meta property="og:description" content="{{ excerpt }}" />

--- a/src/content/posts/2023/hijinx-at-market-basket.md
+++ b/src/content/posts/2023/hijinx-at-market-basket.md
@@ -7,6 +7,8 @@ tags:
 date: 2023-10-16
 excerpt: >
   I’m sharing some photos mostly because I got in trouble for taking them in a Market Basket supermarket in Keene, New Hampshire.
+og:
+  image: https://res.cloudinary.com/dfsssdwbu/image/upload/v1707427658/best-meats_wztdic.jpg
 ---
 
 I’m posting these photos mostly because I got in trouble for taking them in a Market Basket supermarket in Keene, New Hampshire.

--- a/src/content/posts/2023/oak-angels-in-new-hampshire.md
+++ b/src/content/posts/2023/oak-angels-in-new-hampshire.md
@@ -7,6 +7,8 @@ tags:
 date: 2023-11-02
 excerpt: >
   I made oak angels today at the Robert Frost Farm in Derry, New Hampshire, on a day trip with my friend DG. I just dropped down in the duff and scribbled my limbs for a while.
+og:
+  image: https://res.cloudinary.com/dfsssdwbu/image/upload/v1707344572/manchester-nh_fu9d3z.jpg
 ---
 
 I made oak angels today at the Robert Frost Farm in Derry, New Hampshire, on a day trip with my friend DG. I just dropped down in the duff and scribbled my limbs for a while. The oaks are the last to relent before stick season, their leaves so gone hard copper it is difficult to credit that they don’t clank or shatter when they hit the ground.

--- a/src/content/posts/2024/lyza-dot-com-history/lyza-dot-com-beautiful-years.md
+++ b/src/content/posts/2024/lyza-dot-com-history/lyza-dot-com-beautiful-years.md
@@ -7,6 +7,8 @@ tags:
 date: 2024-02-28
 excerpt: >
   For several months in 2009 I developed a feverish hobby: meticulously crafting a visual design for Lyza.com down to the last pixel. Then I applied that lush coat of glamor to my existing content. I call these the Beautiful Years.
+og:
+  image: https://res.cloudinary.com/dfsssdwbu/image/upload/v1708965553/beautiful-years_vhks6s.png
 ---
 
 I have a habit of holding my breath when I look at Lyza.com as it was in 2010. As if these pages would go to dust if I exhaled on them. I'd done the content genesis for years; now I gave it a lavish coat of finery.

--- a/src/content/posts/2024/lyza-dot-com-history/lyza-dot-com-celeste.md
+++ b/src/content/posts/2024/lyza-dot-com-history/lyza-dot-com-celeste.md
@@ -7,6 +7,8 @@ tags:
 date: 2024-02-16
 excerpt: >
   Basically I wrote a bunch of blog software. Again. But I still wasn’t calling it that because I was intent on reinventing a galaxy full of wheels. Tada! It’s Celeste! Look on my Works, ye Mighty, and despair!
+og:
+  image: https://res.cloudinary.com/dfsssdwbu/image/upload/v1708041274/2003-sometimes-celeste-sunny_gvju7k.png
 ---
 
 This — late 2002 through 2005 — is an era of Lyza.com that I look back on with a condescending but genuine sense of affection for my enthusiasm, youth, dumbshittery. Basically I wrote a bunch of blog software. Again. But I still wasn’t calling it that because I was intent on reinventing a galaxy full of wheels. Tada! It’s _Celeste_. _Look on my Works, ye Mighty, and despair!_

--- a/src/content/posts/2024/lyza-dot-com-history/lyza-dot-com-early-glimmers.md
+++ b/src/content/posts/2024/lyza-dot-com-history/lyza-dot-com-early-glimmers.md
@@ -7,6 +7,8 @@ tags:
 date: 2024-02-15
 excerpt: >
   The Internet Archive took its first snapshot of Lyza.com on March 31, 2001.  I could call the time between 1997 and this 2001 crawl the Dark Ages of Lyza.com, but I don't. Instead, during those years, everything was wonderful and ugly.
+og:
+  image: https://res.cloudinary.com/dfsssdwbu/image/upload/v1708033955/lyza-dot-com-2001-03-31_qraerc.png
 ---
 
 The Internet Archive’s Wayback Machine took its [first snapshot of Lyza.com](https://web.archive.org/web/20010331234559/http://www.lyza.com/) on March 31, 2001. I could call the time between 1997 and this 2001 crawl the _Dark Ages_ of Lyza.com because it’s undocumented, and, consistent with the theme, the site’s background was literally black for the first year or two.


### PR DESCRIPTION
This PR adds an 11ty plugin that creates composited Open Graph images for pages and posts.

Content templates can add `og` data to front-matter with an `image` property indicating a post-/page-specific image to use in the generated Open Graph image. This is optional.

Sample Open Graph image with post-specific image:

![image](https://github.com/lyzadanger/lyza-dot-11ty/assets/439947/f0d6681c-8a4c-46c8-b7c9-74df8b8cf602)

and without:

![image](https://github.com/lyzadanger/lyza-dot-11ty/assets/439947/f1ff1210-94e9-4587-ade3-50313c8ee8c5)

This implementation should be seen as a starting point. There's some follow-up I'd like to do, to make images nicer, more resilient, and provide better separation of image specifics and plugin structure. I think I'd also like to make it possible for content to override the OG image composition (i.e. provide specifically the image to use as an Open Graph image, not just an image to use as _part_ of it). Maybe.

Fixes #21 

