### PR TITLE
Establish basic content data types and use them

### DIFF
--- a/lib/cloudinary.ts
+++ b/lib/cloudinary.ts
@@ -1,4 +1,5 @@
 import type { UserConfig } from "@11ty/eleventy";
+import type { ComputedOpenGraphContentData } from "./types";
 
 // TODO Clean this type mess up
 type CloudinaryConfig = {
@@ -7,17 +8,6 @@ type CloudinaryConfig = {
 
 type CloudinaryPluginConfig = {
   cloudinary: CloudinaryConfig;
-};
-
-// TODO This is a dupe
-export type OGData = {
-  /** URL to content-specific Open Graph image, if any */
-  image?: string;
-  /** Fully-qualified canonical URL to content */
-  url?: string;
-
-  description?: string;
-  title: string;
 };
 
 /**
@@ -59,10 +49,7 @@ module.exports = (
   // Return URL to composited Open Graph image
   eleventyConfig.addShortcode(
     "cloudinaryOGImage",
-    /**
-     * @param og - Open Graph data for this piece of content
-     */
-    (og: OGData) => {
+    (og: ComputedOpenGraphContentData) => {
       const encodedTitle = encodeCloudinaryText(og.title);
 
       // Make font larger if there is no post-specific image

--- a/lib/series.ts
+++ b/lib/series.ts
@@ -3,12 +3,7 @@ import { readFileSync } from "fs";
 
 import type { UserConfig } from "@11ty/eleventy";
 
-// TODO: Organize and document types here
-export type Series = {
-  slug: string;
-  title: string;
-  description: string;
-};
+import type { Series } from "./types";
 
 // Pretend 11ty type
 type CollectionAPI = {

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -1,0 +1,79 @@
+// Content Data types
+// `*ContentData` data are declared (in front matter, e.g.) at the most
+// granular level: a single piece of content.
+
+export type OpenGraphContentData = {
+  title?: string;
+  image?: string;
+  url?: string;
+  description?: string;
+};
+
+export type ContentData = {
+  /** All content must declare a title */
+  title: string;
+
+  /** Slug of series this content belongs to */
+  inSeries?: string;
+
+  excerpt?: string;
+  description?: string;
+  tags?: string[];
+  date?: string;
+  og?: OpenGraphContentData;
+};
+
+// Global data types
+
+export type Series = {
+  slug: string;
+  title: string;
+  description: string;
+};
+
+// Merged data
+
+/**
+ * This is a partial representation of the the context object after the build
+ * system (Eleventy) is done merging in data from other parts of the cascade.
+ * This data is the input to me-specific data computation.
+ *
+ * NB: These types should be expanded if they have data fields operated on by
+ *     any of my own code.
+ */
+export type MergedData = ContentData & {
+  /** Eleventy-provided page data */
+  page: Record<string, unknown>;
+
+  // Global data from my own src data modules
+  books: Record<string, unknown>[];
+  config: Record<string, unknown>;
+  education: Record<string, unknown>[];
+  events: Record<string, unknown>[];
+  metadata: {
+    description: string;
+    url: string;
+  };
+  profile: Record<string, unknown>;
+  series: Series[];
+  skills: Record<string, unknown>[];
+};
+
+// Computed data types
+// These represent the data that are in context for template rendering
+
+export type ComputedOpenGraphContentData = OpenGraphContentData & {
+  /** Title is non-optional once OG data is computed/merged */
+  title: string;
+};
+
+/**
+ * This is a partial representation of the returned data object from
+ * me-specific data computation. This is the data context that is provided
+ * to a templates for build.
+ *
+ */
+export type ComputedContentData = MergedData & {
+  /** Open Graph data object is guaranteed to be present */
+  og: ComputedOpenGraphContentData;
+};

--- a/src/_data/eleventyComputed.js
+++ b/src/_data/eleventyComputed.js
@@ -1,33 +1,47 @@
 /**
- * Global computed data merging operations.
+ * Global computed data futzing.
  *
- * Merge local Open Graph template data with global defaults and assure an
- * object of Open Graph data exists for each content item.
+ * Returns an object that operates on merged data from Eleventy and returns
+ * computed content data.
  *
- * @typedef OGData
- *   @prop {string} [image] - Content-specific OG image, if any
- *   @prop {string} [description] - Merged content description or excerpt
- *   @prop {string} title
- *   @prop {string} [url] - Fully-qualified canonical URL to content
+ * @typedef {import('../../lib/types').MergedData} MergedData
+ * @typedef {import('../../lib/types').ComputedContentData} ComputedContentData
  */
 
-module.exports = /** @type OGData */ {
+module.exports = /** @type {<Partial>ComputedContentData}> */ {
+  // Open Graph data
   og: {
-    image: (data) => data.og?.image,
-    description: (data) => {
-      // Order of preference:
-      // 1. data.og.description - when set manually in local data
-      // 2. data.description - prefer to `excerpt` if present
-      // 3. data.excerpt
-      if (data?.og.description) {
-        return data.og.description;
-      }
-      const contentDescription = data.description ?? data.excerpt;
-      return contentDescription ?? data.metadata?.description;
-    },
-    title: (data) => data.title,
-    url: function (data) {
-      return this.htmlBaseUrl(data.page?.url, data.metadata?.url);
-    },
+    image:
+      /**
+       * @param {MergedData} data
+       */
+      (data) => data.og?.image,
+    description:
+      /**
+       * @param {MergedData} data
+       */
+      (data) => {
+        // Order of preference:
+        // 1. data.og.description - when set manually in local data
+        // 2. data.description - prefer to `excerpt` if present
+        // 3. data.excerpt
+        if (data.og?.description) {
+          return data.og.description;
+        }
+        const contentDescription = data.description ?? data.excerpt;
+        return contentDescription ?? data.metadata.description;
+      },
+    title:
+      /**
+       * @param {MergedData} data
+       */
+      (data) => data.title,
+    url:
+      /**
+       * @param {MergedData} data
+       */
+      function (data) {
+        return this.htmlBaseUrl(data.page.url, data.metadata.url);
+      },
   },
 };

--- a/src/_lib/cloudinary.js
+++ b/src/_lib/cloudinary.js
@@ -28,11 +28,7 @@ module.exports = (eleventyConfig, config) => {
         return encodeURIComponent(str.replaceAll(/[\?#,\/\%]/g, encodeURIComponent));
     }
     // Return URL to composited Open Graph image
-    eleventyConfig.addShortcode("cloudinaryOGImage", 
-    /**
-     * @param og - Open Graph data for this piece of content
-     */
-    (og) => {
+    eleventyConfig.addShortcode("cloudinaryOGImage", (og) => {
         const encodedTitle = encodeCloudinaryText(og.title);
         // Make font larger if there is no post-specific image
         const titleSize = og.image ? "54" : "72";

--- a/src/_lib/types.js
+++ b/src/_lib/types.js
@@ -1,0 +1,2 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });


### PR DESCRIPTION
This PR futzes around with establishing some basic content types to help me out when I'm writing stuff that touches Eleventy's stuff. This is loose, but I felt like I needed some form of typing or I'd lose my mind.

No user-facing changes here.

Fixes #83