### PR TITLE
Make Cloudinary OG images more robust and add previews for dev envs

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -24,7 +24,7 @@ module.exports = function (eleventyConfig) {
   // My own plugins
   eleventyConfig.addPlugin(seriesPlugin);
   eleventyConfig.addPlugin(cloudinaryOGPlugin, {
-    cloudinary: siteConfig.cloudinary,
+    cloudinaryId: siteConfig.cloudinary.id,
   });
 
   // Extend markdown transformation with permalinks and footnotes support

--- a/.eleventy.js
+++ b/.eleventy.js
@@ -15,6 +15,8 @@ const cloudinaryOGPlugin = require("./src/_lib/cloudinary");
 
 const siteConfig = require("./src/_data/config");
 
+const colors = require("./styles/colors");
+
 module.exports = function (eleventyConfig) {
   // 11ty plugins
   eleventyConfig.addPlugin(EleventyHtmlBasePlugin);
@@ -25,6 +27,7 @@ module.exports = function (eleventyConfig) {
   eleventyConfig.addPlugin(seriesPlugin);
   eleventyConfig.addPlugin(cloudinaryOGPlugin, {
     cloudinaryId: siteConfig.cloudinary.id,
+    accentColor: colors.pank.DEFAULT,
   });
 
   // Extend markdown transformation with permalinks and footnotes support

--- a/lib/cloudinary.ts
+++ b/lib/cloudinary.ts
@@ -1,13 +1,10 @@
 import type { UserConfig } from "@11ty/eleventy";
 import type { ComputedOpenGraphContentData } from "./types";
 
-// TODO Clean this type mess up
-type CloudinaryConfig = {
-  id: string;
-};
-
 type CloudinaryPluginConfig = {
-  cloudinary: CloudinaryConfig;
+  cloudinary: {
+    id: string;
+  };
 };
 
 /**

--- a/lib/cloudinary.ts
+++ b/lib/cloudinary.ts
@@ -2,9 +2,7 @@ import type { UserConfig } from "@11ty/eleventy";
 import type { ComputedOpenGraphContentData } from "./types";
 
 type CloudinaryPluginConfig = {
-  cloudinary: {
-    id: string;
-  };
+  cloudinaryId: string;
 };
 
 /**
@@ -18,10 +16,8 @@ type CloudinaryPluginConfig = {
  */
 module.exports = (
   eleventyConfig: UserConfig,
-  config: CloudinaryPluginConfig,
+  { cloudinaryId }: CloudinaryPluginConfig,
 ) => {
-  const cloudinaryId = config.cloudinary.id;
-
   if (!cloudinaryId) {
     throw new Error("Lyza-Cloudinary Plugin requires a cloudinary ID");
   }

--- a/lib/cloudinary.ts
+++ b/lib/cloudinary.ts
@@ -4,6 +4,7 @@ import type { ComputedOpenGraphContentData } from "./types";
 
 type CloudinaryPluginConfig = {
   cloudinaryId: string;
+  accentColor: string;
 };
 
 /**
@@ -28,11 +29,13 @@ function encodeCloudinaryText(str: string) {
  */
 module.exports = (
   eleventyConfig: UserConfig,
-  { cloudinaryId }: CloudinaryPluginConfig,
+  { accentColor, cloudinaryId }: CloudinaryPluginConfig,
 ) => {
   if (!cloudinaryId) {
     throw new Error("Lyza-Cloudinary Plugin requires a cloudinary ID");
   }
+
+  const textAccentColor = accentColor.replace("#", "");
 
   const cloudinaryOGImageUrl = (og: ComputedOpenGraphContentData) => {
     const encodedTitle = encodeCloudinaryText(og.title);
@@ -56,7 +59,7 @@ module.exports = (
       // Danger comes last because it's composited on top of the other two
       "co_rgb:000,l_text:Playfair%20Display_72_900:Lyza/fl_layer_apply,g_north_west,x_50,y_40",
       "co_rgb:000,l_text:Playfair%20Display_72_900:Gardner/fl_layer_apply,g_north_west,x_50,y_135",
-      "co_rgb:e60a62,l_text:Playfair%20Display_72_900:Danger/fl_layer_apply,g_north_west,x_70,y_92",
+      `co_rgb:${textAccentColor},l_text:Playfair%20Display_72_900:Danger/fl_layer_apply,g_north_west,x_70,y_92`,
     ];
 
     // If the content has an image to be used, make it half the width of the
@@ -75,7 +78,7 @@ module.exports = (
       // the post image (by design).
       "l_fetch:aHR0cHM6Ly9yZXMuY2xvdWRpbmFyeS5jb20vZGZzc3Nkd2J1L2ltYWdlL3VwbG9hZC92MTcwOTIyNjEyOC9seXphX2loNnJray5naWY=/fl_layer_apply,g_south_east",
       // Render "Lyza.com" on bottom right, near photo of me
-      "co_rgb:e60a62,l_text:Playfair%20Display%20SC_36_bold:Lyza.Com/fl_layer_apply,g_south_east,x_220,y_15",
+      `co_rgb:${textAccentColor},l_text:Playfair%20Display%20SC_36_bold:Lyza.Com/fl_layer_apply,g_south_east,x_220,y_15`,
       // Render the title of the post/content. Last to ensure it's composited
       // on top
       `co_rgb:44403c,l_text:Playfair%20Display_${titleSize}_400_italic_line_spacing_-15:${encodedTitle},${titleLayerOptions}`,

--- a/lib/cloudinary.ts
+++ b/lib/cloudinary.ts
@@ -6,6 +6,17 @@ type CloudinaryPluginConfig = {
 };
 
 /**
+ * A number of characters must be double-encoded to render on a text layer on
+ * Cloudinary. Failure to do so is not a friendly failure mode.
+ *
+ * @see https://support.cloudinary.com/hc/en-us/articles/202521512-How-to-add-a-special-characters-in-text-overlays
+ * @param {String} str - String to encode for use on text layer.
+ */
+function encodeCloudinaryText(str: string) {
+  return encodeURIComponent(str.replaceAll(/[\?#,\/\%]/g, encodeURIComponent));
+}
+
+/**
  * This eleventy plugin provides the `cloudinaryOGImage` shortcode, which
  * returns a URL that can be used as the `content` attribute value
  * in `<meta property="og:image">` tags.
@@ -20,23 +31,6 @@ module.exports = (
 ) => {
   if (!cloudinaryId) {
     throw new Error("Lyza-Cloudinary Plugin requires a cloudinary ID");
-  }
-
-  // A number of characters must be double-escaped to render on a text
-  // layer on Cloudinary. Prepare the title, else failure mode ugly.
-  // https://support.cloudinary.com/hc/en-us/articles/202521512-How-to-add-a-special-characters-in-text-overlays
-
-  /**
-   * A number of characters must be double-encoded to render on a text layer on
-   * Cloudinary. Failure to do so is not a friendly failure mode.
-   *
-   * @see https://support.cloudinary.com/hc/en-us/articles/202521512-How-to-add-a-special-characters-in-text-overlays
-   * @param {String} str - String to encode for use on text layer.
-   */
-  function encodeCloudinaryText(str: string) {
-    return encodeURIComponent(
-      str.replaceAll(/[\?#,\/\%]/g, encodeURIComponent),
-    );
   }
 
   // Return URL to composited Open Graph image

--- a/lib/cloudinary.ts
+++ b/lib/cloudinary.ts
@@ -33,63 +33,62 @@ module.exports = (
     throw new Error("Lyza-Cloudinary Plugin requires a cloudinary ID");
   }
 
+  const cloudinaryOGImageUrl = (og: ComputedOpenGraphContentData) => {
+    const encodedTitle = encodeCloudinaryText(og.title);
+
+    // Make font larger if there is no post-specific image
+    const titleSize = og.image ? "54" : "72";
+
+    // - with content image: text positioned left under LDG type treatment,
+    //     spanning half width of OG image
+    // - no content image: text positioned centered under LDG type treatment,
+    //     spanning most of the width of the OG image
+    const titleLayerOptions = og.image
+      ? "c_fit,w_540/fl_layer_apply,g_north_west,x_50,y_250"
+      : "c_fit,w_800/fl_layer_apply,g_north,y_240";
+
+    const cloudinaryUrlParts = [
+      // Establish the bounds of the image canvas and denote that the end of
+      // the URL will be a URL to "fetch" the backgorund image from
+      `https://res.cloudinary.com/${cloudinaryId}/image/fetch/w_1200,h_630,q_100`,
+      // Static: Render "Lyza / Danger / Gardner" text layers at top left
+      // Danger comes last because it's composited on top of the other two
+      "co_rgb:000,l_text:Playfair%20Display_72_900:Lyza/fl_layer_apply,g_north_west,x_50,y_40",
+      "co_rgb:000,l_text:Playfair%20Display_72_900:Gardner/fl_layer_apply,g_north_west,x_50,y_135",
+      "co_rgb:e60a62,l_text:Playfair%20Display_72_900:Danger/fl_layer_apply,g_north_west,x_70,y_92",
+    ];
+
+    // If the content has an image to be used, make it half the width of the
+    // OG image (taking margins into account), aligned on the right. This
+    // needs to be composited behind some of the following layers.
+    if (og.image) {
+      const encodedURL = Buffer.from(og.image, "utf8").toString("base64");
+      cloudinaryUrlParts.push(
+        `l_fetch:${encodedURL}/fl_layer_apply,c_fit,h_510,w_540,g_east,x_50`,
+      );
+    }
+
+    cloudinaryUrlParts.push(
+      // Render a photo of me in bottom right. This contains a Base-64 encoded
+      // URL to image of me on cloudinary. This image may partially obscure
+      // the post image (by design).
+      "l_fetch:aHR0cHM6Ly9yZXMuY2xvdWRpbmFyeS5jb20vZGZzc3Nkd2J1L2ltYWdlL3VwbG9hZC92MTcwOTIyNjEyOC9seXphX2loNnJray5naWY=/fl_layer_apply,g_south_east",
+      // Render "Lyza.com" on bottom right, near photo of me
+      "co_rgb:e60a62,l_text:Playfair%20Display%20SC_36_bold:Lyza.Com/fl_layer_apply,g_south_east,x_220,y_20",
+      // Render the title of the post/content. Last to ensure it's composited
+      // on top
+      `co_rgb:44403c,l_text:Playfair%20Display_${titleSize}_400_italic_line_spacing_-15:${encodedTitle},${titleLayerOptions}`,
+    );
+
+    // And, finally, give the URL of the image that will be at the
+    // background of all of this, which is just a white rectangle
+    cloudinaryUrlParts.push(
+      "https://res.cloudinary.com/dfsssdwbu/image/upload/v1709226095/white_ldpjpk.jpg",
+    );
+
+    return cloudinaryUrlParts.join("/");
+  };
+
   // Return URL to composited Open Graph image
-  eleventyConfig.addShortcode(
-    "cloudinaryOGImage",
-    (og: ComputedOpenGraphContentData) => {
-      const encodedTitle = encodeCloudinaryText(og.title);
-
-      // Make font larger if there is no post-specific image
-      const titleSize = og.image ? "54" : "72";
-
-      // - with content image: text positioned left under LDG type treatment,
-      //     spanning half width of OG image
-      // - no content image: text positioned centered under LDG type treatment,
-      //     spanning most of the width of the OG image
-      const titleLayerOptions = og.image
-        ? "c_fit,w_540/fl_layer_apply,g_north_west,x_50,y_250"
-        : "c_fit,w_800/fl_layer_apply,g_north,y_240";
-
-      const cloudinaryUrlParts = [
-        // Establish the bounds of the image canvas and denote that the end of
-        // the URL will be a URL to "fetch" the backgorund image from
-        `https://res.cloudinary.com/${cloudinaryId}/image/fetch/w_1200,h_630,q_100`,
-        // Static: Render "Lyza / Danger / Gardner" text layers at top left
-        // Danger comes last because it's composited on top of the other two
-        "co_rgb:000,l_text:Playfair%20Display_72_900:Lyza/fl_layer_apply,g_north_west,x_50,y_40",
-        "co_rgb:000,l_text:Playfair%20Display_72_900:Gardner/fl_layer_apply,g_north_west,x_50,y_135",
-        "co_rgb:e60a62,l_text:Playfair%20Display_72_900:Danger/fl_layer_apply,g_north_west,x_70,y_92",
-      ];
-
-      // If the content has an image to be used, make it half the width of the
-      // OG image (taking margins into account), aligned on the right. This
-      // needs to be composited behind some of the following layers.
-      if (og.image) {
-        const encodedURL = Buffer.from(og.image, "utf8").toString("base64");
-        cloudinaryUrlParts.push(
-          `l_fetch:${encodedURL}/fl_layer_apply,c_fit,h_510,w_540,g_east,x_50`,
-        );
-      }
-
-      cloudinaryUrlParts.push(
-        // Render a photo of me in bottom right. This contains a Base-64 encoded
-        // URL to image of me on cloudinary. This image may partially obscure
-        // the post image (by design).
-        "l_fetch:aHR0cHM6Ly9yZXMuY2xvdWRpbmFyeS5jb20vZGZzc3Nkd2J1L2ltYWdlL3VwbG9hZC92MTcwOTIyNjEyOC9seXphX2loNnJray5naWY=/fl_layer_apply,g_south_east",
-        // Render "Lyza.com" on bottom right, near photo of me
-        "co_rgb:e60a62,l_text:Playfair%20Display%20SC_36_bold:Lyza.Com/fl_layer_apply,g_south_east,x_220,y_20",
-        // Render the title of the post/content. Last to ensure it's composited
-        // on top
-        `co_rgb:44403c,l_text:Playfair%20Display_${titleSize}_400_italic_line_spacing_-15:${encodedTitle},${titleLayerOptions}`,
-      );
-
-      // And, finally, give the URL of the image that will be at the
-      // background of all of this, which is just a white rectangle
-      cloudinaryUrlParts.push(
-        "https://res.cloudinary.com/dfsssdwbu/image/upload/v1709226095/white_ldpjpk.jpg",
-      );
-
-      return cloudinaryUrlParts.join("/");
-    },
-  );
+  eleventyConfig.addShortcode("cloudinaryOGImage", cloudinaryOGImageUrl);
 };

--- a/lib/cloudinary.ts
+++ b/lib/cloudinary.ts
@@ -56,9 +56,9 @@ module.exports = (
         `https://res.cloudinary.com/${cloudinaryId}/image/fetch/w_1200,h_630,q_100`,
         // Static: Render "Lyza / Danger / Gardner" text layers at top left
         // Danger comes last because it's composited on top of the other two
-        "co_rgb:000,l_text:Playfair%20Display_72_900_line:Lyza,c_fit,w_540/fl_layer_apply,g_north_west,x_50,y_40",
-        "co_rgb:000,l_text:Playfair%20Display_72_900_line:Gardner,c_fit,w_540/fl_layer_apply,g_north_west,x_50,y_135",
-        "co_rgb:e60a62,l_text:Playfair%20Display_72_900_line:Danger,c_fit,w_540/fl_layer_apply,g_north_west,x_70,y_92",
+        "co_rgb:000,l_text:Playfair%20Display_72_900:Lyza/fl_layer_apply,g_north_west,x_50,y_40",
+        "co_rgb:000,l_text:Playfair%20Display_72_900:Gardner/fl_layer_apply,g_north_west,x_50,y_135",
+        "co_rgb:e60a62,l_text:Playfair%20Display_72_900:Danger/fl_layer_apply,g_north_west,x_70,y_92",
       ];
 
       // If the content has an image to be used, make it half the width of the
@@ -77,7 +77,7 @@ module.exports = (
         // the post image (by design).
         "l_fetch:aHR0cHM6Ly9yZXMuY2xvdWRpbmFyeS5jb20vZGZzc3Nkd2J1L2ltYWdlL3VwbG9hZC92MTcwOTIyNjEyOC9seXphX2loNnJray5naWY=/fl_layer_apply,g_south_east",
         // Render "Lyza.com" on bottom right, near photo of me
-        "co_rgb:e60a62,l_text:Playfair%20Display%20SC_36_bold_line_spacing_-20:Lyza.Com,c_fit,w_500/fl_layer_apply,g_south_east,x_220,y_20",
+        "co_rgb:e60a62,l_text:Playfair%20Display%20SC_36_bold:Lyza.Com/fl_layer_apply,g_south_east,x_220,y_20",
         // Render the title of the post/content. Last to ensure it's composited
         // on top
         `co_rgb:44403c,l_text:Playfair%20Display_${titleSize}_400_italic_line_spacing_-15:${encodedTitle},${titleLayerOptions}`,

--- a/lib/cloudinary.ts
+++ b/lib/cloudinary.ts
@@ -1,4 +1,5 @@
 import type { UserConfig } from "@11ty/eleventy";
+
 import type { ComputedOpenGraphContentData } from "./types";
 
 type CloudinaryPluginConfig = {
@@ -37,7 +38,7 @@ module.exports = (
     const encodedTitle = encodeCloudinaryText(og.title);
 
     // Make font larger if there is no post-specific image
-    const titleSize = og.image ? "54" : "72";
+    const titleSize = og.image ? "58" : "72";
 
     // - with content image: text positioned left under LDG type treatment,
     //     spanning half width of OG image
@@ -45,7 +46,7 @@ module.exports = (
     //     spanning most of the width of the OG image
     const titleLayerOptions = og.image
       ? "c_fit,w_540/fl_layer_apply,g_north_west,x_50,y_250"
-      : "c_fit,w_800/fl_layer_apply,g_north,y_240";
+      : "c_fit,w_900/fl_layer_apply,g_north,y_240";
 
     const cloudinaryUrlParts = [
       // Establish the bounds of the image canvas and denote that the end of
@@ -64,7 +65,7 @@ module.exports = (
     if (og.image) {
       const encodedURL = Buffer.from(og.image, "utf8").toString("base64");
       cloudinaryUrlParts.push(
-        `l_fetch:${encodedURL}/fl_layer_apply,c_fit,h_510,w_540,g_east,x_50`,
+        `l_fetch:${encodedURL}/fl_layer_apply,c_fit,h_500,w_540,g_east,x_50`,
       );
     }
 
@@ -74,7 +75,7 @@ module.exports = (
       // the post image (by design).
       "l_fetch:aHR0cHM6Ly9yZXMuY2xvdWRpbmFyeS5jb20vZGZzc3Nkd2J1L2ltYWdlL3VwbG9hZC92MTcwOTIyNjEyOC9seXphX2loNnJray5naWY=/fl_layer_apply,g_south_east",
       // Render "Lyza.com" on bottom right, near photo of me
-      "co_rgb:e60a62,l_text:Playfair%20Display%20SC_36_bold:Lyza.Com/fl_layer_apply,g_south_east,x_220,y_20",
+      "co_rgb:e60a62,l_text:Playfair%20Display%20SC_36_bold:Lyza.Com/fl_layer_apply,g_south_east,x_220,y_15",
       // Render the title of the post/content. Last to ensure it's composited
       // on top
       `co_rgb:44403c,l_text:Playfair%20Display_${titleSize}_400_italic_line_spacing_-15:${encodedTitle},${titleLayerOptions}`,

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -31,6 +31,13 @@ export type Series = {
   description: string;
 };
 
+export type Config = {
+  cloudinary: {
+    id: string;
+  };
+  environment: string;
+};
+
 // Merged data
 
 /**
@@ -47,7 +54,7 @@ export type MergedData = ContentData & {
 
   // Global data from my own src data modules
   books: Record<string, unknown>[];
-  config: Record<string, unknown>;
+  config: Config;
   education: Record<string, unknown>[];
   events: Record<string, unknown>[];
   metadata: {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "watch:11ty": "eleventy --serve --quiet",
     "watch:css": "tailwindcss -c styles/tailwind.config.js -i styles/tailwind.css -o _tmp/styles.css --watch --postcss",
     "watch:ts": "tsc --outDir src/_lib --watch",
-    "start": "NODE_ENV=development npm-run-all clean build:ts -p watch:* -- --watch"
+    "start": "ELEVENTY_ENV=development npm-run-all clean build:ts -p watch:* -- --watch"
   },
   "keywords": [],
   "author": "",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "watch:11ty": "eleventy --serve --quiet",
     "watch:css": "tailwindcss -c styles/tailwind.config.js -i styles/tailwind.css -o _tmp/styles.css --watch --postcss",
     "watch:ts": "tsc --outDir src/_lib --watch",
-    "start": "npm-run-all clean build:ts -p watch:* -- --watch"
+    "start": "NODE_ENV=development npm-run-all clean build:ts -p watch:* -- --watch"
   },
   "keywords": [],
   "author": "",

--- a/src/_data/config.js
+++ b/src/_data/config.js
@@ -1,4 +1,5 @@
 // Non-sensitive technical site config
 module.exports = {
   cloudinary: { id: "dfsssdwbu" },
+  environment: process.env.NODE_ENV || "development",
 };

--- a/src/_data/config.js
+++ b/src/_data/config.js
@@ -1,5 +1,5 @@
 // Non-sensitive technical site config
 module.exports = {
   cloudinary: { id: "dfsssdwbu" },
-  environment: process.env.NODE_ENV || "development",
+  environment: process.env.ELEVENTY_ENV || "production",
 };

--- a/src/_includes/layouts/base.njk
+++ b/src/_includes/layouts/base.njk
@@ -58,10 +58,30 @@
           {{ content | safe }}
         {% endblock %}
       </div>
-
-      {%- block footer -%}
-        {%- include 'partials/_footer.njk' -%}
-      {%- endblock -%}
+      {% block ogPreview %}
+        {% if config.environment === 'development' %}
+          <div class="border border-pank">
+            <div class="bg-pank px-2 py-1 text-right text-white">
+              <i>Open Graph preview</i>
+            </div>
+            <div class="flex flex-col gap-4 p-2 md:flex-row">
+              <div class="min-w-0 max-w-[240px] p-1">
+                <a href="{% cloudinaryOGImage og %}" target="_blank"
+                  ><img src="{% cloudinaryOGImage og %}" class="border"
+                /></a>
+              </div>
+              <div class="prose prose-stone max-w-none leading-snug">
+                <p><b>{{ og.title }}</b></p>
+                <p>{{ og.description }}</p>
+                <p class="text-right font-sans text-sm">{{ og.url }}</p>
+              </div>
+            </div>
+          </div>
+        {% endif %}
+        {%- block footer -%}
+          {%- include 'partials/_footer.njk' -%}
+        {%- endblock -%}
+      {% endblock %}
     </div>
   </body>
 </html>

--- a/src/_lib/cloudinary.js
+++ b/src/_lib/cloudinary.js
@@ -19,10 +19,11 @@ function encodeCloudinaryText(str) {
  *
  * https://cloudinary.com/documentation/transformation_reference
  */
-module.exports = (eleventyConfig, { cloudinaryId }) => {
+module.exports = (eleventyConfig, { accentColor, cloudinaryId }) => {
     if (!cloudinaryId) {
         throw new Error("Lyza-Cloudinary Plugin requires a cloudinary ID");
     }
+    const textAccentColor = accentColor.replace("#", "");
     const cloudinaryOGImageUrl = (og) => {
         const encodedTitle = encodeCloudinaryText(og.title);
         // Make font larger if there is no post-specific image
@@ -42,7 +43,7 @@ module.exports = (eleventyConfig, { cloudinaryId }) => {
             // Danger comes last because it's composited on top of the other two
             "co_rgb:000,l_text:Playfair%20Display_72_900:Lyza/fl_layer_apply,g_north_west,x_50,y_40",
             "co_rgb:000,l_text:Playfair%20Display_72_900:Gardner/fl_layer_apply,g_north_west,x_50,y_135",
-            "co_rgb:e60a62,l_text:Playfair%20Display_72_900:Danger/fl_layer_apply,g_north_west,x_70,y_92",
+            `co_rgb:${textAccentColor},l_text:Playfair%20Display_72_900:Danger/fl_layer_apply,g_north_west,x_70,y_92`,
         ];
         // If the content has an image to be used, make it half the width of the
         // OG image (taking margins into account), aligned on the right. This
@@ -57,7 +58,7 @@ module.exports = (eleventyConfig, { cloudinaryId }) => {
         // the post image (by design).
         "l_fetch:aHR0cHM6Ly9yZXMuY2xvdWRpbmFyeS5jb20vZGZzc3Nkd2J1L2ltYWdlL3VwbG9hZC92MTcwOTIyNjEyOC9seXphX2loNnJray5naWY=/fl_layer_apply,g_south_east", 
         // Render "Lyza.com" on bottom right, near photo of me
-        "co_rgb:e60a62,l_text:Playfair%20Display%20SC_36_bold:Lyza.Com/fl_layer_apply,g_south_east,x_220,y_15", 
+        `co_rgb:${textAccentColor},l_text:Playfair%20Display%20SC_36_bold:Lyza.Com/fl_layer_apply,g_south_east,x_220,y_15`, 
         // Render the title of the post/content. Last to ensure it's composited
         // on top
         `co_rgb:44403c,l_text:Playfair%20Display_${titleSize}_400_italic_line_spacing_-15:${encodedTitle},${titleLayerOptions}`);

--- a/src/_lib/cloudinary.js
+++ b/src/_lib/cloudinary.js
@@ -1,6 +1,16 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 /**
+ * A number of characters must be double-encoded to render on a text layer on
+ * Cloudinary. Failure to do so is not a friendly failure mode.
+ *
+ * @see https://support.cloudinary.com/hc/en-us/articles/202521512-How-to-add-a-special-characters-in-text-overlays
+ * @param {String} str - String to encode for use on text layer.
+ */
+function encodeCloudinaryText(str) {
+    return encodeURIComponent(str.replaceAll(/[\?#,\/\%]/g, encodeURIComponent));
+}
+/**
  * This eleventy plugin provides the `cloudinaryOGImage` shortcode, which
  * returns a URL that can be used as the `content` attribute value
  * in `<meta property="og:image">` tags.
@@ -9,23 +19,9 @@ Object.defineProperty(exports, "__esModule", { value: true });
  *
  * https://cloudinary.com/documentation/transformation_reference
  */
-module.exports = (eleventyConfig, config) => {
-    const cloudinaryId = config.cloudinary.id;
+module.exports = (eleventyConfig, { cloudinaryId }) => {
     if (!cloudinaryId) {
         throw new Error("Lyza-Cloudinary Plugin requires a cloudinary ID");
-    }
-    // A number of characters must be double-escaped to render on a text
-    // layer on Cloudinary. Prepare the title, else failure mode ugly.
-    // https://support.cloudinary.com/hc/en-us/articles/202521512-How-to-add-a-special-characters-in-text-overlays
-    /**
-     * A number of characters must be double-encoded to render on a text layer on
-     * Cloudinary. Failure to do so is not a friendly failure mode.
-     *
-     * @see https://support.cloudinary.com/hc/en-us/articles/202521512-How-to-add-a-special-characters-in-text-overlays
-     * @param {String} str - String to encode for use on text layer.
-     */
-    function encodeCloudinaryText(str) {
-        return encodeURIComponent(str.replaceAll(/[\?#,\/\%]/g, encodeURIComponent));
     }
     // Return URL to composited Open Graph image
     eleventyConfig.addShortcode("cloudinaryOGImage", (og) => {
@@ -45,9 +41,9 @@ module.exports = (eleventyConfig, config) => {
             `https://res.cloudinary.com/${cloudinaryId}/image/fetch/w_1200,h_630,q_100`,
             // Static: Render "Lyza / Danger / Gardner" text layers at top left
             // Danger comes last because it's composited on top of the other two
-            "co_rgb:000,l_text:Playfair%20Display_72_900_line:Lyza,c_fit,w_540/fl_layer_apply,g_north_west,x_50,y_40",
-            "co_rgb:000,l_text:Playfair%20Display_72_900_line:Gardner,c_fit,w_540/fl_layer_apply,g_north_west,x_50,y_135",
-            "co_rgb:e60a62,l_text:Playfair%20Display_72_900_line:Danger,c_fit,w_540/fl_layer_apply,g_north_west,x_70,y_92",
+            "co_rgb:000,l_text:Playfair%20Display_72_900:Lyza/fl_layer_apply,g_north_west,x_50,y_40",
+            "co_rgb:000,l_text:Playfair%20Display_72_900:Gardner/fl_layer_apply,g_north_west,x_50,y_135",
+            "co_rgb:e60a62,l_text:Playfair%20Display_72_900:Danger/fl_layer_apply,g_north_west,x_70,y_92",
         ];
         // If the content has an image to be used, make it half the width of the
         // OG image (taking margins into account), aligned on the right. This
@@ -62,7 +58,7 @@ module.exports = (eleventyConfig, config) => {
         // the post image (by design).
         "l_fetch:aHR0cHM6Ly9yZXMuY2xvdWRpbmFyeS5jb20vZGZzc3Nkd2J1L2ltYWdlL3VwbG9hZC92MTcwOTIyNjEyOC9seXphX2loNnJray5naWY=/fl_layer_apply,g_south_east", 
         // Render "Lyza.com" on bottom right, near photo of me
-        "co_rgb:e60a62,l_text:Playfair%20Display%20SC_36_bold_line_spacing_-20:Lyza.Com,c_fit,w_500/fl_layer_apply,g_south_east,x_220,y_20", 
+        "co_rgb:e60a62,l_text:Playfair%20Display%20SC_36_bold:Lyza.Com/fl_layer_apply,g_south_east,x_220,y_20", 
         // Render the title of the post/content. Last to ensure it's composited
         // on top
         `co_rgb:44403c,l_text:Playfair%20Display_${titleSize}_400_italic_line_spacing_-15:${encodedTitle},${titleLayerOptions}`);

--- a/src/_lib/cloudinary.js
+++ b/src/_lib/cloudinary.js
@@ -23,8 +23,7 @@ module.exports = (eleventyConfig, { cloudinaryId }) => {
     if (!cloudinaryId) {
         throw new Error("Lyza-Cloudinary Plugin requires a cloudinary ID");
     }
-    // Return URL to composited Open Graph image
-    eleventyConfig.addShortcode("cloudinaryOGImage", (og) => {
+    const cloudinaryOGImageUrl = (og) => {
         const encodedTitle = encodeCloudinaryText(og.title);
         // Make font larger if there is no post-specific image
         const titleSize = og.image ? "54" : "72";
@@ -66,5 +65,7 @@ module.exports = (eleventyConfig, { cloudinaryId }) => {
         // background of all of this, which is just a white rectangle
         cloudinaryUrlParts.push("https://res.cloudinary.com/dfsssdwbu/image/upload/v1709226095/white_ldpjpk.jpg");
         return cloudinaryUrlParts.join("/");
-    });
+    };
+    // Return URL to composited Open Graph image
+    eleventyConfig.addShortcode("cloudinaryOGImage", cloudinaryOGImageUrl);
 };

--- a/src/_lib/cloudinary.js
+++ b/src/_lib/cloudinary.js
@@ -26,14 +26,14 @@ module.exports = (eleventyConfig, { cloudinaryId }) => {
     const cloudinaryOGImageUrl = (og) => {
         const encodedTitle = encodeCloudinaryText(og.title);
         // Make font larger if there is no post-specific image
-        const titleSize = og.image ? "54" : "72";
+        const titleSize = og.image ? "58" : "72";
         // - with content image: text positioned left under LDG type treatment,
         //     spanning half width of OG image
         // - no content image: text positioned centered under LDG type treatment,
         //     spanning most of the width of the OG image
         const titleLayerOptions = og.image
             ? "c_fit,w_540/fl_layer_apply,g_north_west,x_50,y_250"
-            : "c_fit,w_800/fl_layer_apply,g_north,y_240";
+            : "c_fit,w_900/fl_layer_apply,g_north,y_240";
         const cloudinaryUrlParts = [
             // Establish the bounds of the image canvas and denote that the end of
             // the URL will be a URL to "fetch" the backgorund image from
@@ -49,7 +49,7 @@ module.exports = (eleventyConfig, { cloudinaryId }) => {
         // needs to be composited behind some of the following layers.
         if (og.image) {
             const encodedURL = Buffer.from(og.image, "utf8").toString("base64");
-            cloudinaryUrlParts.push(`l_fetch:${encodedURL}/fl_layer_apply,c_fit,h_510,w_540,g_east,x_50`);
+            cloudinaryUrlParts.push(`l_fetch:${encodedURL}/fl_layer_apply,c_fit,h_500,w_540,g_east,x_50`);
         }
         cloudinaryUrlParts.push(
         // Render a photo of me in bottom right. This contains a Base-64 encoded
@@ -57,7 +57,7 @@ module.exports = (eleventyConfig, { cloudinaryId }) => {
         // the post image (by design).
         "l_fetch:aHR0cHM6Ly9yZXMuY2xvdWRpbmFyeS5jb20vZGZzc3Nkd2J1L2ltYWdlL3VwbG9hZC92MTcwOTIyNjEyOC9seXphX2loNnJray5naWY=/fl_layer_apply,g_south_east", 
         // Render "Lyza.com" on bottom right, near photo of me
-        "co_rgb:e60a62,l_text:Playfair%20Display%20SC_36_bold:Lyza.Com/fl_layer_apply,g_south_east,x_220,y_20", 
+        "co_rgb:e60a62,l_text:Playfair%20Display%20SC_36_bold:Lyza.Com/fl_layer_apply,g_south_east,x_220,y_15", 
         // Render the title of the post/content. Last to ensure it's composited
         // on top
         `co_rgb:44403c,l_text:Playfair%20Display_${titleSize}_400_italic_line_spacing_-15:${encodedTitle},${titleLayerOptions}`);

--- a/styles/colors.js
+++ b/styles/colors.js
@@ -1,0 +1,17 @@
+module.exports = {
+  // These are from https://uicolors.app/create based on the DEFAULT
+  pank: {
+    50: "#fff0f7",
+    100: "#ffe4f2",
+    200: "#ffc9e7",
+    300: "#ff9dd1",
+    400: "#ff60b0",
+    500: "#ff3190",
+    600: "#e60a62",
+    DEFAULT: "#e60a62",
+    700: "#d6004f",
+    800: "#b00441",
+    900: "#92093a",
+    950: "#5a001e",
+  },
+};

--- a/styles/tailwind.config.js
+++ b/styles/tailwind.config.js
@@ -1,23 +1,7 @@
 const colors = require("tailwindcss/colors");
 const defaultTheme = require("tailwindcss/defaultTheme");
 
-// These are from https://uicolors.app/create based on the DEFAULT
-const customColors = {
-  pank: {
-    50: "#fff0f7",
-    100: "#ffe4f2",
-    200: "#ffc9e7",
-    300: "#ff9dd1",
-    400: "#ff60b0",
-    500: "#ff3190",
-    600: "#e60a62",
-    DEFAULT: "#e60a62",
-    700: "#d6004f",
-    800: "#b00441",
-    900: "#92093a",
-    950: "#5a001e",
-  },
-};
+const customColors = require("./colors");
 
 module.exports = {
   content: ["_site/**/*.{html,md,njk}"],


### PR DESCRIPTION
This PR ticks off a number of tasks associated with the Eleventy Cloudinary Open Graph image plugin:

* Refactor API and internally lightly to be more sensible about config and dependencies
* Abstract out the accent color (pank)
* Removes a few unnecessary URL segments from the generated URL and tweaks the layout and size of text layers
* Adds a (phew!) Open Graph preview area at the bottom of pages when building in dev envs

User-facing changes here:

* Subtle text size/position changes in generated OG images
* Open Graph preview, but dev only

When `ELEVENTY_ENV` is set to `development`, Open Graph preview images look like this:

<img width="1091" alt="image" src="https://github.com/lyzadanger/lyza-dot-11ty/assets/439947/ec398ee9-5738-4450-9dc5-b1749b672d50">

