### PR TITLE
Fix layout of blog post tags list when there are many tags

### DIFF
--- a/src/_includes/_post.njk
+++ b/src/_includes/_post.njk
@@ -1,6 +1,6 @@
 {%- macro postItem(post) -%}
   <div
-    class="border-t-3 border-solid border-grey-900 sm:flex sm:flex-col sm:gap-y-1"
+    class="space-y-2 border-t-3 border-solid border-grey-900 sm:flex sm:flex-col sm:gap-y-1"
   >
     <div>
       <a
@@ -13,17 +13,23 @@
           </h3>
         {% endif %}
       </a>
-
-      <div class="border-b sm:flex sm:items-center sm:gap-x-1">
-        <h4 class="text-l whitespace-nowrap font-display font-normal italic">
+      {# Display date and tags. For sm and larger viewports, this is a flex row #}
+      <div class="border-b pb-1 sm:flex sm:gap-x-1 md:gap-x-2 md:pb-0">
+        <h4
+          class="text-l whitespace-nowrap font-display font-normal italic sm:-mt-1"
+        >
           {{ post.date | localeDate }}
         </h4>
-        <div class="sm:flex-grow">
-          <ul class="flex flex-row gap-2 font-smallcaps sm:justify-end">
+        <div class="sm:flex-grow sm:text-right">
+          <ul class="font-smallcaps leading-none sm:justify-end">
             {% for tag in post.data.tags | postTags %}
-              <li class="font-smallcaps text-sm text-grey-600">
+              {# tag list elements are spaced depending on whether they are
+                 left-aligned (narrow screens) or right-aligned (wider) #}
+              <li
+                class="my-px mr-1 inline-block font-smallcaps text-sm text-grey-600 last:mr-0 sm:my-0 sm:ml-1 sm:mr-0"
+              >
                 <a
-                  class="transition-colors hover:text-pank"
+                  class="leading-none transition-colors hover:text-pank"
                   href="/tags/{{ tag | slugify }}"
                   >#{{ tag }}</a
                 >

--- a/src/_includes/layouts/post.njk
+++ b/src/_includes/layouts/post.njk
@@ -26,10 +26,10 @@ navigationKey: posts
         </div>
       </div>
     {% endif %}
-    <ul class="flex flex-row gap-2 font-smallcaps">
+    <ul class="font-smallcaps">
       {% set postTags = tags | postTags %}
       {% for tag in postTags %}
-        <li>
+        <li class="mr-1 inline-block last:mr-0">
           <a
             href="/tags/{{ tag | slugify }}"
             class="font-smallcaps text-sm text-grey-600 transition-colors hover:text-pank hover:underline"


### PR DESCRIPTION
I was laying out blog-post tag lists using a flex row, which created a fragile layout that couldn't accommodate longer lists of tags (i.e. it wouldn't wrap). Lists converted to `inline-block` list elements and the issue is now fixed.

## Before

<img width="1128" alt="Screenshot 2024-07-24 at 10 03 23 AM" src="https://github.com/user-attachments/assets/9a02e8ae-d3c6-4489-acda-81106f81f736">

<img width="821" alt="Screenshot 2024-07-24 at 10 02 59 AM" src="https://github.com/user-attachments/assets/075a253b-0ef9-4886-a926-a49a3b728d69">

<img width="497" alt="Screenshot 2024-07-24 at 10 03 09 AM" src="https://github.com/user-attachments/assets/3d7a4e88-5473-4781-af36-4490a4d9eda2">

## After

<img width="780" alt="Screenshot 2024-07-24 at 10 00 57 AM" src="https://github.com/user-attachments/assets/15d74f77-4a1f-4cab-9429-f04ad03eaf2b">

<img width="496" alt="Screenshot 2024-07-24 at 10 01 17 AM" src="https://github.com/user-attachments/assets/b81d255f-2365-438f-b681-02845de8bf3f">

<img width="352" alt="Screenshot 2024-07-24 at 10 01 39 AM" src="https://github.com/user-attachments/assets/a4cab373-da0e-4b52-8431-e819f53bac64">

Fixes #79